### PR TITLE
Add -DEBUG suffix to the version name. Changes to build.gradle to support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,6 +7,8 @@ android {
     defaultConfig {
         minSdkVersion 8
         targetSdkVersion 19
+        versionCode 156
+        versionName "5.3.6"
     }
 
     buildTypes {
@@ -18,6 +20,7 @@ android {
             //This adds a ".debug" to the package name so we can install it side-by-side with
             //release package
             packageNameSuffix '.debug'
+            versionNameSuffis '-DEBUG'
         }
     }
 }


### PR DESCRIPTION
This adds versionCode and versionName to the build.gradle file. They are supposed to overwrite those two values in the AndroidManifest on build, and should therefore be changed in the build.gradle from now on.

This allows the use of versionNameSuffix in the debug configuration to append "-DEBUG" or any other string to the version name attribute. Instead of 1.5.3 on the version name for debug builds, it will say 1.5.3-DEBUG. 
