### PR TITLE
Allow installation on devices without GPS/network location

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,4 +60,7 @@ Redistribution and use in source and binary forms, with or without modification,
             </intent-filter>
         </activity>
     </application>
+    <uses-feature android:name="android.hardware.location" android:required="false" />
+    <uses-feature android:name="android.hardware.location.network" android:required="false" />
+    <uses-feature android:name="android.hardware.location.gps" android:required="false" />
 </manifest>


### PR DESCRIPTION
The Google Play Store interprets the permissions ACCESS_FINE_LOCATION and ACCESS_COARSE_LOCATION as implying that GPS and network location are required, respectively.  With the External I/O plugin installed, though, Avare is useful on devices without GPS, so we should specify that these hardware features are not required.
