### PR TITLE
Fix problem with comma in "address," Find field and share from Google Maps

### DIFF
--- a/src/com/ds/avare/SearchActivity.java
+++ b/src/com/ds/avare/SearchActivity.java
@@ -399,9 +399,9 @@ public class SearchActivity extends Activity implements Observer {
                 
                 if(s.toString().startsWith("address,")) {
                     String [] vals = new String[1];
-                    String addr[] = s.toString().split(",");
-                    if(addr.length > 1) {
-                        StringPreference sp = new StringPreference(Destination.MAPS, Destination.MAPS, Destination.MAPS, addr[1]);
+                    String addr = s.toString().substring(8); // 8 = length of "address,"
+                    if(addr.length() > 1) {
+                        StringPreference sp = new StringPreference(Destination.MAPS, Destination.MAPS, Destination.MAPS, addr);
                         vals[0] = sp.getHashedName();
                         mAdapter = new SearchAdapter(SearchActivity.this, vals);
                         mSearchListView.setAdapter(mAdapter);

--- a/src/com/ds/avare/storage/StringPreference.java
+++ b/src/com/ds/avare/storage/StringPreference.java
@@ -94,7 +94,9 @@ public class StringPreference {
      * @return
      */
     static public String formatAddressName(String name) {
-        return name.replaceAll("http:.*", "").replaceAll(",", " ").replaceAll("\n", "");
+    	// Change \n to space.  Google might pass the address like the following:
+    	// 123 Main St\n\nGotham City, New Jersey
+        return name.replaceAll("http:.*", "").replaceAll(",", " ").replaceAll("\n", " ");
     }
 
     /**


### PR DESCRIPTION
The problem in SearchActivity.java was that it only passed everything between the comma in address, and the next comma, so if the user input "address,123 Main St, Olathe, KS 66221", all that was passed was "123 Main St".

I converted \n to space instead of nothing since when I was testing this Google Maps was passing something like the following "123 Main St\n\nOlathe, KS 66221", so the code interpreted that as "123 Main StOlathe KS 66221".
