### PR TITLE
Plan NDB appears to be selected instead of VOR when both have same ID

### DIFF
--- a/src/com/ds/avare/SearchActivity.java
+++ b/src/com/ds/avare/SearchActivity.java
@@ -126,13 +126,13 @@ public class SearchActivity extends Activity implements Observer {
      * 
      * @param dst
      */
-    private void goTo(String dst, String type) {
+    private void goTo(String dst, String type, String dbType) {
         mIsWaypoint = false;
         mDestination = new Destination(dst, type, mPref, mService);
         mDestination.addObserver(SearchActivity.this);
         mToast.setText(getString(R.string.Searching) + " " + dst);
         mToast.show();
-        mDestination.find();
+        mDestination.find(dbType);
         mSearchText.setText("");
     }
 
@@ -140,13 +140,13 @@ public class SearchActivity extends Activity implements Observer {
      * 
      * @param dst
      */
-    private void planTo(String dst, String type) {
+    private void planTo(String dst, String type, String dbType) {
         mIsWaypoint = true;
         mDestination = new Destination(dst, type, mPref, mService);
         mDestination.addObserver(SearchActivity.this);
         mToast.setText(getString(R.string.Searching) + " " + dst);
         mToast.show();
-        mDestination.find();
+        mDestination.find(dbType);
         mSearchText.setText("");
     }
 
@@ -276,10 +276,12 @@ public class SearchActivity extends Activity implements Observer {
                 if(null != mSelected) {
                     String id = StringPreference.parseHashedNameId(mSelected); 
                     String destType = StringPreference.parseHashedNameDestType(mSelected); 
+                    String dbType = StringPreference.parseHashedNameDbType(mSelected);
                     if(id == null || destType == null) {
                         return;
                     }
-                    planTo(id, destType);
+                    // It's ok if dbType is null
+                    planTo(id, destType, dbType);
                 }
             }
         });
@@ -319,10 +321,12 @@ public class SearchActivity extends Activity implements Observer {
                 String txt = mAdapter.getItem(position).replace(",", " ");
                 String id = StringPreference.parseHashedNameId(txt); 
                 String destType = StringPreference.parseHashedNameDestType(txt); 
+                String dbType = StringPreference.parseHashedNameDbType(txt);
                 if(id == null || destType == null) {
                     return;
                 }
-                goTo(id, destType);
+                // It's ok if dbType is null
+                goTo(id, destType, dbType);
             }
         });
         

--- a/src/com/ds/avare/place/Destination.java
+++ b/src/com/ds/avare/place/Destination.java
@@ -22,8 +22,8 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
-
 import java.util.Observable;
+
 import com.ds.avare.StorageService;
 import com.ds.avare.gps.GpsParams;
 import com.ds.avare.position.Projection;
@@ -309,19 +309,32 @@ public class Destination extends Observable {
          */
         mLooking = true;
         DataBaseLocationTask locmDataBaseTask = new DataBaseLocationTask();
-        locmDataBaseTask.execute(true);
+        locmDataBaseTask.execute(true, "");
+    }
+    
+    /**
+     * Database  query to find destination
+     */
+    public void find() {
+        /*
+         * Do in background as database queries are disruptive
+         */
+        mLooking = true;
+        DataBaseLocationTask locmDataBaseTask = new DataBaseLocationTask();
+        locmDataBaseTask.execute(false, "");
     }
 
 	/**
 	 * Database  query to find destination
+	 * @param dbType
 	 */
-	public void find() {
+	public void find(String dbType) {
 	    /*
 	     * Do in background as database queries are disruptive
 	     */
         mLooking = true;
         DataBaseLocationTask locmDataBaseTask = new DataBaseLocationTask();
-        locmDataBaseTask.execute(false);
+        locmDataBaseTask.execute(false, dbType);
 	}
 	
     /**
@@ -346,6 +359,7 @@ public class Destination extends Observable {
             Thread.currentThread().setName("Destination");
 
             Boolean guess = (Boolean)vals[0];
+            String dbType = (String)vals[1];
             
             /*
              * If we dont know type, find with a guess.
@@ -469,7 +483,7 @@ public class Destination extends Observable {
 	        /*
 	         * For all others, find in DB
 	         */
-	        mDataSource.findDestination(mName, mDestType, mParams, mRunways, mFreq, mAwos);
+	        mDataSource.findDestination(mName, mDestType, dbType, mParams, mRunways, mFreq, mAwos);
 
 	        if(mDestType.equals(BASE)) {
 	            

--- a/src/com/ds/avare/storage/DataBaseHelper.java
+++ b/src/com/ds/avare/storage/DataBaseHelper.java
@@ -833,7 +833,7 @@ public class DataBaseHelper  {
      * @param params
      * @return
      */
-    public void findDestination(String name, String type, LinkedHashMap<String, String> params, LinkedList<Runway> runways, LinkedHashMap<String, String> freq, LinkedList<Awos> awos) {
+    public void findDestination(String name, String type, String dbType, LinkedHashMap<String, String> params, LinkedList<Runway> runways, LinkedHashMap<String, String> freq, LinkedList<Awos> awos) {
         
         Cursor cursor;
         
@@ -848,7 +848,14 @@ public class DataBaseHelper  {
             types = TABLE_FIX;
         }
 
-        String qry = "select * from " + types + " where " + LOCATION_ID_DB + "=='" + name + "';";
+        String qry = "select * from " + types + " where " + LOCATION_ID_DB + "=='" + name + "'";
+        if(null != dbType && dbType.length() > 0) {
+            qry += " and " + TYPE_DB + "=='" + dbType + "'";
+        }
+        // Order by type desc will cause VOR to be ahead of NDB if both are available.
+        // This is a bit of a hack, but the user probably wants the VOR more than the NDB
+        qry += " order by " + TYPE_DB + " desc;";
+        
         cursor = doQuery(qry, getMainDb());
 
         try {

--- a/src/com/ds/avare/storage/DataSource.java
+++ b/src/com/ds/avare/storage/DataSource.java
@@ -92,8 +92,8 @@ public class DataSource {
      * @param name
      * @param params
      */
-    public void findDestination(String name, String type, LinkedHashMap<String, String> params, LinkedList<Runway> runways, LinkedHashMap<String, String> freq,  LinkedList<Awos> awos) {
-        dbHelper.findDestination(name, type, params, runways, freq, awos);
+    public void findDestination(String name, String type, String dbType, LinkedHashMap<String, String> params, LinkedList<Runway> runways, LinkedHashMap<String, String> freq,  LinkedList<Awos> awos) {
+        dbHelper.findDestination(name, type, dbType, params, runways, freq, awos);
     }
     
     /**


### PR DESCRIPTION
This should fix issue #52

This will fix the issue when using Search, either the VOR or NDB can be selected.
In Plan, there is now no way to select the NDB if a VOR and NDB share the same name, before, the NDB would be selected, which is probably not what most people want.  This is what Zubair suggested.
