### PR TITLE
add ability to enable persistent chart option button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ local.properties
 
 # required to GCM
 private_data.xml
+
+# Gradle
+.gradle
+build

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         applicationId "com.ds.avare"

--- a/app/src/main/java/com/ds/avare/LocationActivity.java
+++ b/app/src/main/java/com/ds/avare/LocationActivity.java
@@ -132,6 +132,7 @@ public class LocationActivity extends Activity implements Observer {
     private TwoButton mDrawButton;
     private Button mWebButton;
     private OptionButton mChartOption;
+    private OptionButton mChartOptionPersistent;
     private OptionButton mLayerOption;
     private Bundle mExtras;
     private boolean mIsWaypoint;
@@ -534,12 +535,30 @@ public class LocationActivity extends Activity implements Observer {
             public Object callback(Object o, Object o1) {
                 mPref.setChartType("" + (int) o1);
                 mLocationView.forceReload();
+                mChartOptionPersistent.setCurrentSelectionIndex(Integer.parseInt(mPref.getChartType()));
                 return null;
             }
         });
         mChartOption.setOptions(Boundaries.getChartTypes());
         mChartOption.setCurrentSelectionIndex(Integer.parseInt(mPref.getChartType()));
         mLocationView.forceReload();
+
+        mChartOptionPersistent = (OptionButton)view.findViewById(R.id.location_spinner_chart_persistent);
+        mChartOptionPersistent.setCallback(new GenericCallback() {
+            @Override
+            public Object callback(Object o, Object o1) {
+                mPref.setChartType("" + (int) o1);
+                mLocationView.forceReload();
+                mChartOption.setCurrentSelectionIndex(Integer.parseInt(mPref.getChartType()));
+                return null;
+            }
+        });
+        mChartOptionPersistent.setOptions(Boundaries.getChartTypes());
+        mChartOptionPersistent.setCurrentSelectionIndex(Integer.parseInt(mPref.getChartType()));
+
+        if (mPref.showPersistentChartOptionButton()) {
+            mChartOptionPersistent.setVisibility(View.VISIBLE);
+        }
 
 
         mLayerOption = (OptionButton)view.findViewById(R.id.location_spinner_layer);
@@ -946,7 +965,7 @@ public class LocationActivity extends Activity implements Observer {
         mAnimateSim = new AnimateButton(LocationActivity.this, mSimButton, AnimateButton.DIRECTION_R_L, mPlanNext);
         mAnimateTrack = new AnimateButton(LocationActivity.this, mLayerOption, AnimateButton.DIRECTION_R_L, mPlanPause);
         mAnimateChart = new AnimateButton(LocationActivity.this, mChartOption, AnimateButton.DIRECTION_R_L, (View[])null);
-        mAnimateHelp = new AnimateButton(LocationActivity.this, mHelpButton, AnimateButton.DIRECTION_L_R, mCenterButton, mDrawButton, mMenuButton);
+        mAnimateHelp = new AnimateButton(LocationActivity.this, mHelpButton, AnimateButton.DIRECTION_L_R, mCenterButton, mDrawButton, mMenuButton, mChartOptionPersistent);
         mAnimateDownload = new AnimateButton(LocationActivity.this, mDownloadButton, AnimateButton.DIRECTION_L_R, (View[])null);
         mAnimatePref = new AnimateButton(LocationActivity.this, mPrefButton, AnimateButton.DIRECTION_L_R, (View[])null);
 

--- a/app/src/main/java/com/ds/avare/storage/Preferences.java
+++ b/app/src/main/java/com/ds/avare/storage/Preferences.java
@@ -846,6 +846,13 @@ public class Preferences {
     /**
      * @return
      */
+    public boolean showPersistentChartOptionButton() {
+        return mPref.getBoolean(mContext.getString(R.string.prefPersistentChartOptionButton), false);
+    }
+
+    /**
+     * @return
+     */
     public String getUDWLocation() {
         try {
             return mPref.getString(mContext.getString(R.string.UDWLocation), "");

--- a/app/src/main/res/layout/location.xml
+++ b/app/src/main/res/layout/location.xml
@@ -76,6 +76,14 @@ Redistribution and use in source and binary forms, with or without modification,
             android:drawableLeft="@android:drawable/ic_menu_more"
             android:visibility="visible" />
 
+        <com.ds.avare.utils.OptionButton
+            android:id="@+id/location_spinner_chart_persistent"
+            android:layout_width="110dp"
+            android:layout_height="wrap_content"
+            android:layout_above="@+id/location_button_menu"
+            android:labelFor="@string/ChartTypeLabel"
+            android:visibility="invisible" />
+
         <Button
             android:id="@+id/plan_prev"
             android:textStyle="bold"
@@ -258,7 +266,7 @@ Redistribution and use in source and binary forms, with or without modification,
                 android:layout_below="@+id/location_popout_buttons"
 	            android:layout_width="wrap_content"
 	            android:layout_height="wrap_content"/>
-            
+
         </RelativeLayout>
         
         

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -420,6 +420,9 @@ Redistribution and use in source and binary forms, with or without modification,
     <string name="prefPlanControl">&quot;PlanControl&quot;</string>
     <string name="prefPlanControlLabel">&quot;Show Flight Plan Controls&quot;</string>
     <string name="prefPlanControlSummary">&quot;Select to display flight plan control buttons on chart view&quot;</string>
+    <string name="prefPersistentChartOptionButton">&quot;PersistenChartOptionButton&quot;</string>
+    <string name="prefPersistentChartOptionButtonLabel">&quot;Show Persistent Chart Button&quot;</string>
+    <string name="prefPersistentChartOptionButtonSummary">&quot;Select to display persistent chart selection button on chart view&quot;</string>
     <string name="switchTanks">&quot;Switch Fuel Tanks&quot;</string>
     <string name="CAPGrid">&quot;CAPGrids&quot;</string>
     <string name="CAPGridSummary">&quot;Select to show the US Civil Air Patrol grids on the map.&quot;</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -277,6 +277,11 @@ authors: zkhan, jlmcgraw
             android:key="@string/prefPlanControl"
             android:summary="@string/prefPlanControlSummary"
             android:title="@string/prefPlanControlLabel" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/prefPersistentChartOptionButton"
+            android:summary="@string/prefPersistentChartOptionButtonSummary"
+            android:title="@string/prefPersistentChartOptionButtonLabel" />
         <com.ds.avare.utils.ListPreferenceWithSummary
             android:defaultValue="0"
             android:entries="@array/DisplayIconPrompt"

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:2.1.2'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Thu Jun 16 23:12:13 PDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip


### PR DESCRIPTION
Adds the ability to enable (disabled by default) a persistent chart selection button on the map view above the menu button on the bottom left. Main use case for me was that switching back and forth between Sectional and TAC was getting cumbersome in flight. Ideally I'd like a way to do that with a single button press, but I couldn't come up with a great interface for that. Or even better, an option to do it automatically based on whether or not you are outside the boundaries of the TAC. Let me know if you have other suggestions/ideas.