### PR TITLE
Map long press

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ local.properties
 
 # required to GCM
 private_data.xml
+
+# Gradle
+.gradle
+build

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "24"
 
     defaultConfig {
         applicationId "com.ds.avare"

--- a/app/src/main/java/com/ds/avare/LocationActivity.java
+++ b/app/src/main/java/com/ds/avare/LocationActivity.java
@@ -541,6 +541,19 @@ public class LocationActivity extends Activity implements Observer {
         mChartOption.setCurrentSelectionIndex(Integer.parseInt(mPref.getChartType()));
         mLocationView.forceReload();
 
+        final MainActivity mainActivity = (MainActivity) getParent();
+        View tabView = mainActivity.getTabWidget().getChildTabViewAt(MainActivity.tabMain);
+        tabView.setOnLongClickListener(
+                new View.OnLongClickListener() {
+                    @Override
+                    public boolean onLongClick(View v) {
+                        if (mainActivity.getTabHost().getCurrentTab() == MainActivity.tabMain) {
+                            mChartOption.performClick();
+                        }
+                        return false;
+                    }
+                }
+        );
 
         mLayerOption = (OptionButton)view.findViewById(R.id.location_spinner_layer);
         mLayerOption.setCallback(new GenericCallback() {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:2.1.2'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip


### PR DESCRIPTION
This is another possible way to make it slightly easier to change the chart type. This does not add any new buttons like the other PR, but just adds a long click listener to the "Map" tab at the bottom.