### PR TITLE
Save KML if app closed with swipe

### DIFF
--- a/app/src/main/java/com/ds/avare/LocationActivity.java
+++ b/app/src/main/java/com/ds/avare/LocationActivity.java
@@ -1010,7 +1010,6 @@ public class LocationActivity extends Activity implements Observer {
                                 Uri.fromFile(new File(fileURI.getPath())));
                         startActivity(emailIntent);
                     } catch (Exception e) {
-
                     }
                     break;
 
@@ -1369,6 +1368,10 @@ public class LocationActivity extends Activity implements Observer {
     @Override
     public void onDestroy() {
         super.onDestroy();
+        // Save the current track log
+        if(mService!=null && mService.getTracks()) {
+            setTrackState(false);
+        }
     }
 
     /**


### PR DESCRIPTION
If LocationActivity destroyed (ie. application accidently swiped off the task list) the logging is stopped gracefully instead of just dropped.

https://groups.google.com/d/msg/apps4av-forum/tSn3NO7E56I/J-cpIiO3AQAJ