### PR TITLE
Add preference to auto start tracking

### DIFF
--- a/app/src/main/java/com/ds/avare/LocationActivity.java
+++ b/app/src/main/java/com/ds/avare/LocationActivity.java
@@ -1010,7 +1010,6 @@ public class LocationActivity extends Activity implements Observer {
                                 Uri.fromFile(new File(fileURI.getPath())));
                         startActivity(emailIntent);
                     } catch (Exception e) {
-
                     }
                     break;
 
@@ -1145,6 +1144,9 @@ public class LocationActivity extends Activity implements Observer {
 
             mLayerOption.setSelectedValue(mPref.getLayerType());
             mLocationView.setLayerType(mPref.getLayerType());
+
+            // auto start tracking
+            startTracks();
 
         }
 
@@ -1460,6 +1462,18 @@ public class LocationActivity extends Activity implements Observer {
         Handler h = new Handler();
         for(int ms = 500; ms <= 5000; ms+=500) {
         	h.postDelayed(r, ms);
+        }
+    }
+
+    private void startTracks() {
+        if(mPref.getAutoStartTracking()) {
+            // if service available and not currently logging
+            if(mService!=null && !mService.getTracks()) {
+                // Start the track log
+                setTrackState(true);
+                // update button
+                mTracksButton.setChecked(true);
+            }
         }
     }
 }

--- a/app/src/main/java/com/ds/avare/storage/Preferences.java
+++ b/app/src/main/java/com/ds/avare/storage/Preferences.java
@@ -1200,6 +1200,9 @@ public class Preferences {
         return mPref.getBoolean(mContext.getString(R.string.b1map), false);
     }
 
+    public boolean getAutoStartTracking() {
+        return (mPref.getBoolean(mContext.getString(R.string.prefAutoStartTracking), false));
+    }
 
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -216,6 +216,9 @@ Redistribution and use in source and binary forms, with or without modification,
     <string name="AutoPostTracksTitle">&quot;Send tracks file to &quot;</string>
     <string name="AutoPostTracksSubject">&quot;Avare flight tracking data - &quot;</string>
     <string name="prefAutoPostTracks">AutoPostTracks</string>
+    <string name="AutoStartTrackingLabel">&quot;Auto Start Tracking&quot;</string>
+    <string name="AutoStartTrackingSummary">&quot;Select to automatically turn tracking on when the application starts&quot;</string>
+    <string name="prefAutoStartTracking">AutoStartTracking</string>
     <string name="AutoPostTracksLabel">&quot;Automatic Track Post&quot;</string>
     <string name="AutoPostTracksSummary">&quot;Select what to do with the KML tracks file when closed&quot;</string>
     <string name="AutoPostTracksDialogText">&quot;The tracks file %s has been saved&quot;</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -302,6 +302,10 @@ authors: zkhan, jlmcgraw
             android:key="@string/TrkUpdShowHistory"
             android:title="@string/TrkUpdShowHistoryLabel"
             android:summary="@string/TrkUpdShowHistorySummary"/>
+        <CheckBoxPreference
+            android:key="@string/prefAutoStartTracking"
+            android:title="@string/AutoStartTrackingLabel"
+            android:summary="@string/AutoStartTrackingSummary"/>
         <com.ds.avare.utils.ListPreferenceWithSummary
             android:defaultValue="@string/Zero"
             android:entries="@array/AutoPostTracksPrompts"


### PR DESCRIPTION
https://groups.google.com/d/msg/apps4av-forum/tSn3NO7E56I/rJsOvxs_AwAJ

I like to use this option too, I have the helper automatically connect to WiFi, Launch Avare, and now auto start tracking, makes for an easy 1 click option rather than have to open the helper, setup wifi, then launch Avare, then click menu, then the tracks off button. This way I mount my phone on the dash and then click the io helper and everything starts.