### PR TITLE
Flush KML to disk ~60s when moving

### DIFF
--- a/app/src/main/java/com/ds/avare/flightLog/KMLRecorder.java
+++ b/app/src/main/java/com/ds/avare/flightLog/KMLRecorder.java
@@ -76,6 +76,7 @@ public class KMLRecorder {
 	 */
 	private Config			mConfig;				// Configuration record passed in at start() call
 	private BufferedWriter  mTracksFile;			// File handle to use for writing the data
+	private long		    mTracksFileFlushed = 0; // last time the tracks file was flushed
     private File            mFile;					// core file handler
     private LinkedList<GpsParams> mPositionHistory; // Stored GPS points 
 	private URI 			mFileURI;				// The URI of the file created for these datapoints
@@ -303,7 +304,7 @@ public class KMLRecorder {
     		// File closed means nothing to do
     		return;
     	}
-		
+
 		if((gpsParams.getSpeed() < mConfig.mStartSpeed)) {
 			// Not going fast enough yet to record
 			return;
@@ -343,6 +344,12 @@ public class KMLRecorder {
 			mTracksFile.write ("\t\t\t\t\t" + gpsParams.getLongitude() + "," + 
 											  gpsParams.getLatitude() + "," + 
 											 (gpsParams.getAltitude() * .3048) + "\n");
+			// flush the file every minute or so
+			long now=(new Date()).getTime();
+			if(now-mTracksFileFlushed>60000) {
+				mTracksFileFlushed=now;
+				mTracksFile.flush();;
+			}
 
 			// Add this position to our linked list for possible display
 			// on the charts


### PR DESCRIPTION
Flush the KML file to disk periodically in case the app crashes or power fails.
I'm not that up on KML and it looks like there is no time stamp in the spec for the coordinate tag, so if the app does crash/run out of bat, the user is really left with 1/2 the info which, while slightly better than a 0 length file, it isn't that great...
I'm curious, do we need these coordinates? Or could we just write the new points placemarks out every minute or so?
Could we write the points first and put this placemark at the bottom of the file? It seems like a bung file would be slightly more useful if it was points first...
