### PR TITLE
JS - update the android buildToolsVersion to work with the latest ver…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ android:
     - tools
     - platform-tools
     # The BuildTools version used by the project
-    - build-tools-23.0.1
+    - build-tools-25.0.0
     # The SDK version used to compile the project
-    - android-23
+    - android-25
     # Additional components, otherwise bild fails to find license signature
     - extra-google-google_play_services
     - extra-google-m2repository

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         applicationId "com.ds.avare"
         minSdkVersion 10
-        targetSdkVersion 23
+        targetSdkVersion 25
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.3.1'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Oct 16 21:31:47 EDT 2016
+#Wed Apr 05 23:38:00 PDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
 update the android buildToolsVersion to work with the latest version of android (Nougat 7.1.1); update the version for the android gradle tools in the travis file;