### PR TITLE
Tabs - fit more buttons to avoid scrolling tabs in large and xlarge

### DIFF
--- a/app/src/main/res/drawable-large/bg_selected.xml
+++ b/app/src/main/res/drawable-large/bg_selected.xml
@@ -20,11 +20,10 @@ Redistribution and use in source and binary forms, with or without modification,
         android:endColor="#4682b4" android:angle="-90" />
 
     <size
-        android:width="120dp"
-        android:height="60dp"/>
+        android:width="60dp"
+        android:height="50dp"/>
 
     <corners
-        android:radius="15dp"
-/>
+        android:radius="5dp"/>
 
 </shape>

--- a/app/src/main/res/drawable-large/bg_unselected.xml
+++ b/app/src/main/res/drawable-large/bg_unselected.xml
@@ -15,10 +15,12 @@ Redistribution and use in source and binary forms, with or without modification,
     <stroke
         android:width="1dip"
         android:color="#000000" />
+    
     <gradient android:startColor="#000000" android:centerColor="#000000"
         android:endColor="#000000" android:angle="-90" />
+    
     <size
-        android:width="120dp"
-        android:height="60dp"/>
+        android:width="60dp"
+        android:height="50dp"/>
 
 </shape>

--- a/app/src/main/res/drawable-xlarge/bg_selected.xml
+++ b/app/src/main/res/drawable-xlarge/bg_selected.xml
@@ -20,11 +20,11 @@ Redistribution and use in source and binary forms, with or without modification,
         android:endColor="#4682b4" android:angle="-90" />
 
     <size
-        android:width="150dp"
-        android:height="70dp"/>
+        android:width="100dp"
+        android:height="60dp"/>
 
     <corners
-        android:radius="20dp"
+        android:radius="5dp"
 />
 
 </shape>

--- a/app/src/main/res/drawable-xlarge/bg_unselected.xml
+++ b/app/src/main/res/drawable-xlarge/bg_unselected.xml
@@ -15,10 +15,12 @@ Redistribution and use in source and binary forms, with or without modification,
     <stroke
         android:width="1dip"
         android:color="#000000" />
+    
     <gradient android:startColor="#000000" android:centerColor="#000000"
         android:endColor="#000000" android:angle="-90" />
+    
     <size
-        android:width="150dp"
-        android:height="70dp"/>
+        android:width="100dp"
+        android:height="60dp"/>
 
 </shape>


### PR DESCRIPTION
This makes Near, PFD and 3D accessible with one-click.

"After" in large resolution (Nexus 7" emulator - looks the same as on my hardware):
https://i.imgur.com/Ubrnige.png
https://i.imgur.com/PMdode8.png

"After" in xlarge resolution (Pixel C 10.2" emulator)
https://i.imgur.com/UPhipVm.jpg
https://i.imgur.com/Z7BQUVB.jpg