### PR TITLE
Improved parsing of APT.txt to use ICAO codes.

### DIFF
--- a/extra/data/airport.pl
+++ b/extra/data/airport.pl
@@ -30,7 +30,14 @@ while (<FILE>) {
     if (m/^APT/) {
         #sanitize input text for output to csv
         $_ =~ s/,|"/ /g;
-        $id   = ltrim( rtrim( substr( $_, 27,  4 ) ) );
+        $icaoID = ltrim( rtrim( substr( $_, 1210,  4 ) ) );
+        $iataID = ltrim( rtrim( substr( $_, 27,  4 ) ) );
+        if ( $icaoID eq "" ) {
+            $id   = $iataID;
+        }
+        else {
+            $id   = $icaoID;
+        }
         $type = ltrim( rtrim( substr( $_, 14,  12 ) ) );
         $name = ltrim( rtrim( substr( $_, 133, 50 ) ) );
         $state = ltrim( rtrim( substr( $_, 91, 2 ) ) );


### PR DESCRIPTION
What do you think of this change?  It tries to use the ICAO code first, else defaults to the IATA code listed.  This is an attempt to get Alaska airports searchable by ICAO codes, not just IATA 3 letter codes.