### PR TITLE
Prevent a divide by zero crash if there is only enough room for 1 fie…

### DIFF
--- a/app/src/main/java/com/ds/avare/utils/InfoLines.java
+++ b/app/src/main/java/com/ds/avare/utils/InfoLines.java
@@ -569,9 +569,10 @@ public class InfoLines {
         }
 
         // There might be leftover space. Divide it so that it pads between
-        // the fields
+        // the fields.
         int nLeftoverSpace = mDisplayWidth - maxFieldsPerLine * mFieldWidth;
-        int nPadding = nLeftoverSpace / (maxFieldsPerLine - 1);
+        int nPadding = (maxFieldsPerLine > 1) ?
+                (nLeftoverSpace / (maxFieldsPerLine - 1)) : nLeftoverSpace;
 
         // Now calculate the horizontal position of each field
         int nRightShift = nPadding;


### PR DESCRIPTION
…ld in the top status line area.

Still unknown as to why getWidth() returns a value smaller than the display size when drawing. This preventive fix ensures there won't be a divide by zero error when calculating how many fields can be drawn.