### PR TITLE
Use bitmap filtering for improved chart rendering

### DIFF
--- a/app/src/main/java/com/ds/avare/views/LocationView.java
+++ b/app/src/main/java/com/ds/avare/views/LocationView.java
@@ -248,6 +248,7 @@ public class LocationView extends View implements MultiTouchObjectCanvas<Object>
         mGpsParams = new GpsParams(null);
         mPaint = new Paint();
         mPaint.setAntiAlias(true);
+        mPaint.setFilterBitmap(true);
         mPointProjection = null;
         mDraw = false;
 


### PR DESCRIPTION
This PR adds bitmap filtering to the LocationView. This results in reduced pixelation when fully zoomed in.  It also reduces artifacts when moving the map a zoomed out view.
(This may already be the default setting on some devices.  For example my Nexus 9 does not default to bitmap filtering, but my Pixel 3XL does.)

Before:
![Screenshot_bbefore](https://user-images.githubusercontent.com/2163396/82694914-57da4e80-9c21-11ea-9cce-69830038d3b9.png)

After:
![Screenshot_after](https://user-images.githubusercontent.com/2163396/82694943-658fd400-9c21-11ea-8bd7-a829deeb04ea.png)
