### PR TITLE
Modifying ICAO flight plan generation to work with non-ICAO airport identifiers

### DIFF
--- a/app/src/main/assets/wxb.html
+++ b/app/src/main/assets/wxb.html
@@ -108,6 +108,20 @@ function plan_fill(
 				pilotInCommand,
 				pilotInfo) {
 
+				// non-ICAO destinations and departures need to be replaced with ZZZZ, and the
+				// actual identifier moved to the Other Information field prefixed with either
+				// DEP/ or DEST/
+				if (departure.startsWith('K') && departure.search(/\d/) != -1) {
+					if (otherInfo) { otherInfo += ' '; }
+					otherInfo += 'DEP/' + departure.substring(1, 4);
+					departure = 'ZZZZ';
+				}
+				if (destination.startsWith('K') && destination.search(/\d/) != -1) {
+					if (otherInfo) { otherInfo += ' '; }
+					otherInfo += 'DEST/' + destination.substring(1,4);
+					destination = 'ZZZZ';
+				}
+
 				document.getElementById("icaoAircraftIdInput").value = aircraftId;
 
 				var sel1 = document.getElementById("icaoFlightTypeSelection");


### PR DESCRIPTION
When preparing an ICAO flight plan, the current implementation of the flight plan preparation function in Avare naively puts all airport identifiers into the Destination and Departure fields.  The US has many small airports whose identifiers don't conform to ICAO name specifications: they have numbers in them.  When this occurs, the non-conforming identifier is to be replaced with ZZZZ, and a note made in the Other Information field, as specified here:

https://www.faa.gov/air_traffic/publications/atpubs/fs_html/appendix_a.html

This pull request makes a simple test of the departure and destination fields when filling out the form: does the airport identifier start with K (to limit its effect to US airports), and does it contain a number?  If so, it replaces the appropriate field's data with ZZZZ, and adds either DEST/ or DEP/ with the ICAO-invalid identifier.