### PR TITLE
cleanup exceptions that are never thrown

### DIFF
--- a/app/src/main/java/com/ds/avare/utils/SAXXMLHandlerMETAR.java
+++ b/app/src/main/java/com/ds/avare/utils/SAXXMLHandlerMETAR.java
@@ -39,8 +39,7 @@ public class SAXXMLHandlerMETAR extends DefaultHandler {
     }
  
     // Event Handlers
-    public void startElement(String uri, String localName, String qName,
-            Attributes attributes) throws SAXException {
+    public void startElement(String uri, String localName, String qName, Attributes attributes) {
         mTempVal = "";
         if(qName.equalsIgnoreCase("METAR")) {
             mTempText = new String();
@@ -48,13 +47,11 @@ public class SAXXMLHandlerMETAR extends DefaultHandler {
         }
     }
  
-    public void characters(char[] ch, int start, int length)
-            throws SAXException {
+    public void characters(char[] ch, int start, int length) {
         mTempVal += new String(ch, start, length);
     }
  
-    public void endElement(String uri, String localName, String qName)
-            throws SAXException {
+    public void endElement(String uri, String localName, String qName) {
         if (qName.equalsIgnoreCase("raw_text")) {
             mTempText = mTempVal;
         }

--- a/app/src/main/java/com/ds/avare/utils/SAXXMLHandlerPIREP.java
+++ b/app/src/main/java/com/ds/avare/utils/SAXXMLHandlerPIREP.java
@@ -40,7 +40,7 @@ public class SAXXMLHandlerPIREP extends DefaultHandler {
  
     // Event Handlers
     public void startElement(String uri, String localName, String qName,
-            Attributes attributes) throws SAXException {
+            Attributes attributes) {
         mTempVal = "";
         if(qName.equalsIgnoreCase("PIREP")) {
             mTempText = new String();
@@ -48,13 +48,11 @@ public class SAXXMLHandlerPIREP extends DefaultHandler {
         }
     }
  
-    public void characters(char[] ch, int start, int length)
-            throws SAXException {
+    public void characters(char[] ch, int start, int length) {
         mTempVal += new String(ch, start, length);
     }
  
-    public void endElement(String uri, String localName, String qName)
-            throws SAXException {
+    public void endElement(String uri, String localName, String qName) {
         if (qName.equalsIgnoreCase("raw_text")) {
             mTempText = mTempVal;
         }

--- a/app/src/main/java/com/ds/avare/utils/SAXXMLHandlerTAF.java
+++ b/app/src/main/java/com/ds/avare/utils/SAXXMLHandlerTAF.java
@@ -34,20 +34,18 @@ public class SAXXMLHandlerTAF extends DefaultHandler {
  
     // Event Handlers
     public void startElement(String uri, String localName, String qName,
-            Attributes attributes) throws SAXException {
+            Attributes attributes) {
         mTempVal = "";
         if(qName.equalsIgnoreCase("TAF")) {
             mTempText = new String();
         }
     }
  
-    public void characters(char[] ch, int start, int length)
-            throws SAXException {
+    public void characters(char[] ch, int start, int length) {
         mTempVal += new String(ch, start, length);
     }
  
-    public void endElement(String uri, String localName, String qName)
-            throws SAXException {
+    public void endElement(String uri, String localName, String qName) {
         if (qName.equalsIgnoreCase("raw_text")) {
             mTempText = mTempVal;
         }


### PR DESCRIPTION
These methods never throw a SAXException exception. Therefore, remove the exception.
.
Should make the code cleaner and the VM able to do better optimizations.