### PR TITLE
Closes #372

### DIFF
--- a/app/src/main/java/com/ds/avare/utils/CapitalizeAndEditTextPreferenceWithSummary.java
+++ b/app/src/main/java/com/ds/avare/utils/CapitalizeAndEditTextPreferenceWithSummary.java
@@ -1,0 +1,49 @@
+/*
+Copyright (c) 2012, Apps4Av Inc. (apps4av.com)
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    *     * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    *
+    *     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ds.avare.utils;
+
+import android.content.Context;
+import android.preference.EditTextPreference;
+import android.util.AttributeSet;
+
+/**
+ *
+ * @author jackwilliard
+ *
+ */
+public class CapitalizeAndEditTextPreferenceWithSummary extends EditTextPreference {
+
+    private String originalSummary = "";
+
+    public CapitalizeAndEditTextPreferenceWithSummary(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        originalSummary = super.getSummary().toString();
+    }
+
+    public CapitalizeAndEditTextPreferenceWithSummary(Context context) {
+        super(context);
+        originalSummary = super.getSummary().toString();
+    }
+
+    @Override
+    public void setText(String value) {
+        super.setText(value.toUpperCase());
+        setSummary(originalSummary + " (" + value + ")");
+    }
+
+    @Override
+    public void setSummary(CharSequence summary) {
+        super.setSummary(originalSummary + " (" + getText().toUpperCase() + ")");
+    }
+}
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -441,7 +441,7 @@ Redistribution and use in source and binary forms, with or without modification,
     <string name="AircraftTypeSummary">Aircraft type for filing</string>
 
     <string name="AircraftICAOCode">Aircraft ICAO Code</string>
-    <string name="AircraftICAOCodeSummary">Aircraft ICAO code 24-bit decimal</string>
+    <string name="AircraftICAOCodeSummary">Aircraft ICAO code in hexidecimal</string>
 
     <string name="AircraftColorPrimary">Aircraft Color - First</string>
     <string name="AircraftColorPrimarySummary">First aircraft color for filing</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -364,27 +364,27 @@ authors: zkhan, jlmcgraw
         android:title="@string/userData"
         android:icon="@android:drawable/ic_menu_manage" >
 
-        <com.ds.avare.utils.EditTextPreferenceWithSummary
+        <com.ds.avare.utils.CapitalizeAndEditTextPreferenceWithSummary
             android:title="@string/PilotContact"
             android:summary="@string/PilotContactSummary"
             android:key="@string/PilotContact"/>
 
-        <com.ds.avare.utils.EditTextPreferenceWithSummary
+        <com.ds.avare.utils.CapitalizeAndEditTextPreferenceWithSummary
             android:title="@string/AircraftHomeBase"
             android:summary="@string/AircraftHomeBaseSummary"
             android:key="@string/AircraftHomeBase"/>
 
-        <com.ds.avare.utils.EditTextPreferenceWithSummary
+        <com.ds.avare.utils.CapitalizeAndEditTextPreferenceWithSummary
             android:title="@string/AircraftTailNumber"
             android:summary="@string/AircraftTailNumberSummary"
             android:key="@string/AircraftTailNumber"/>
 
-        <com.ds.avare.utils.EditTextPreferenceWithSummary
+        <com.ds.avare.utils.CapitalizeAndEditTextPreferenceWithSummary
             android:title="@string/AircraftType"
             android:summary="@string/AircraftTypeSummary"
             android:key="@string/AircraftType"/>
 
-        <com.ds.avare.utils.EditTextPreferenceWithSummary
+        <com.ds.avare.utils.CapitalizeAndEditTextPreferenceWithSummary
             android:title="@string/AircraftICAOCode"
             android:summary="@string/AircraftICAOCodeSummary"
             android:key="@string/AircraftICAOCode"/>
@@ -403,17 +403,17 @@ authors: zkhan, jlmcgraw
             android:summary="@string/AircraftColorSecondarySummary"
             android:title="@string/AircraftColorSecondary" />
 
-        <com.ds.avare.utils.EditTextPreferenceWithSummary
+        <com.ds.avare.utils.CapitalizeAndEditTextPreferenceWithSummary
             android:key="@string/AircraftEquipment"
             android:summary="@string/AircraftEquipmentSummary"
             android:title="@string/AircraftEquipment" />
 
-        <com.ds.avare.utils.EditTextPreferenceWithSummary
+        <com.ds.avare.utils.CapitalizeAndEditTextPreferenceWithSummary
             android:key="@string/AircraftSurveillance"
             android:summary="@string/AircraftSurveillanceSummary"
             android:title="@string/AircraftSurveillance" />
 
-        <com.ds.avare.utils.EditTextPreferenceWithSummary
+        <com.ds.avare.utils.CapitalizeAndEditTextPreferenceWithSummary
             android:title="@string/AircraftTAS"
             android:summary="@string/AircraftTASSummary"
             android:key="@string/AircraftTAS"/>


### PR DESCRIPTION
This is a requested user feature.

Addresses the issue that ICAO codes were called decimal, although they are hexidecimal.  The summary in the preferences field is confusing.

Addresses the issue that user input is not capitalized in the preferences and FAA form. The form is already capitalized on submission, but this is not apparent to the user.

An additional class very similar to an existing class was added to match the existing Android interface.  Note: this interface is deprecated.