### PR TITLE
Bump the minimum supported API version to 19 (KitKat)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId "com.ds.avare"
-        minSdkVersion 18 // Required for lossless and transparent webp
+        minSdkVersion 19 // Required for lossless and transparent webp
         targetSdkVersion 28
     }
 


### PR DESCRIPTION
Bump the minimum supported API version to 19, the KitKat release.

The previous version was not widely supported. KitKat is widely supported on what
remaining Android devices that are out there. KitKat focused primarily on optimizing
the operating system for improved performance. KitKat also has numerous security
fixes. In particular, an OpenSSL bug.