### PR TITLE
Add back inadvertently removed button text

### DIFF
--- a/app/src/main/assets/plan.html
+++ b/app/src/main/assets/plan.html
@@ -609,10 +609,10 @@ $(document).ready(function(){
                 <td id="plan_count"></td>
             </tr>
             <tr>
-                <td><button class="btn btn-block" id="list_first" onclick="first()"></button></td>
-                <td><button class="btn btn-block" id="list_prev" onclick="prev()"></button></td>
-                <td><button class="btn btn-block" id="list_next" onclick="next()"></button></td>
-                <td><button class="btn btn-block" id="list_last" onclick="last()"></button></td>
+                <td><button class="btn btn-block" id="list_first" onclick="first()">&lt;&lt;</button></td>
+                <td><button class="btn btn-block" id="list_prev" onclick="prev()">&lt;</button></td>
+                <td><button class="btn btn-block" id="list_next" onclick="next()">&gt;</button></td>
+                <td><button class="btn btn-block" id="list_last" onclick="last()">&gt;&gt;</button></td>
             </tr>
         </table>
         <table class="table">


### PR DESCRIPTION
Fixes #414 introduced by #393. The desired button text was appropriately HTML escaped from `<` and `>` to `&lt;` and `&gt;` respectively.

Before:
![Screenshot_20201107-232929](https://user-images.githubusercontent.com/2163396/98458890-73df9700-2152-11eb-8c2a-3585c61497b0.png)

After:
![Screenshot_20201107-233022](https://user-images.githubusercontent.com/2163396/98458899-7fcb5900-2152-11eb-9d8f-3fdefbbf35f0.png)

