### PR TITLE
Add rotate button to Plates.  Closes #245.

### DIFF
--- a/app/src/main/java/com/ds/avare/PlatesActivity.java
+++ b/app/src/main/java/com/ds/avare/PlatesActivity.java
@@ -75,6 +75,7 @@ public class PlatesActivity extends Activity implements Observer  {
     private Button mAirportButton;
     private Button mPlatesButton;
     private Button mApproachButton;
+    private Button mRotateButton;
     private Button mPlatesTagButton;
     private Button mPlatesTimerButton;
     private AlertDialog mPlatesPopup;
@@ -482,6 +483,19 @@ public class PlatesActivity extends Activity implements Observer  {
             }
         });
 
+        mRotateButton = (Button)view.findViewById(R.id.plates_button_rotate);
+        mRotateButton.getBackground().setAlpha(255);
+        mRotateButton.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                mPlatesView.advancePlateRotationNinetyDegrees();
+            }
+        });
+        if(mPref.isTrackUpPlates()) {
+            mRotateButton.setVisibility(View.INVISIBLE);
+        } else {
+            mRotateButton.setVisibility(View.VISIBLE);
+        }
 
         mPlatesTagButton = (Button)view.findViewById(R.id.plates_button_tag);
         mPlatesTagButton.getBackground().setAlpha(255);
@@ -917,6 +931,12 @@ public class PlatesActivity extends Activity implements Observer  {
         }
         else {
             mCenterButton.getBackground().setColorFilter(0xFF444444, PorterDuff.Mode.MULTIPLY);
+        }
+
+        if(mPref.isTrackUpPlates()) {
+            mRotateButton.setVisibility(View.INVISIBLE);
+        } else {
+            mRotateButton.setVisibility(View.VISIBLE);
         }
     }
    

--- a/app/src/main/res/layout/plates.xml
+++ b/app/src/main/res/layout/plates.xml
@@ -32,10 +32,22 @@ Redistribution and use in source and binary forms, with or without modification,
         android:layout_centerInParent="true"
         android:background="@drawable/button_small"
         android:layout_margin="5dp"
-        android:layout_alignParentBottom="true"/>
+        android:layout_alignParentBottom="true"
+        android:visibility="invisible" />
 
 
-        <Button
+    <Button
+        android:id="@+id/plates_button_rotate"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentRight="true"
+        android:layout_below="@+id/plates_header"
+        android:background="@drawable/button_small"
+        android:text="@string/Rotate"
+        android:textStyle="bold"
+        android:visibility="visible" />
+
+    <Button
     	        android:id="@+id/plates_button_tag"
     	        android:textStyle="bold"
     	        android:layout_centerVertical="true"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -514,6 +514,7 @@ Redistribution and use in source and binary forms, with or without modification,
     <string name="WindsAloftCeilingSummary">&quot;Select Winds Aloft display ceiling in thousands of feet&quot;</string>
 
     <string name="Tag">Tag</string>
+    <string name="Rotate">Rotate</string>
     <string name="PointName">Name of point</string>
     <string name="Geotag">Geotag</string>
     <string name="Verify">Verify</string>


### PR DESCRIPTION
Closes #245. Adds a rotate button to the airport diagrams and approach plates.  This button does not appear in Track Up mode.

Each click of the button rotates the diagram 90 degrees clockwise.

Four files are affected within the UI code.