### PR TITLE
Adds a leading "0" when adsb targets that are 9 hundred feet or less from current pressure altitude

### DIFF
--- a/app/src/main/java/com/ds/avare/adsb/Traffic.java
+++ b/app/src/main/java/com/ds/avare/adsb/Traffic.java
@@ -180,7 +180,14 @@ public class Traffic {
                     continue;
                 }
                 diff = (int)Math.round(diff / 100.0);
-                text += (diff > 0 ? "+" : "") + diff;
+                
+                if(diff > 0) {
+                    text += "+" + (diff < 10 ? "0" : "") + diff;
+                } else if(diff < 0) {
+                    text += "-" + (diff > -10 ? "0" : "") + Math.abs(diff);
+                } else {
+                    text += "0" + diff;
+                }
             }
 
             float radius;


### PR DESCRIPTION
Warning: I dont have a test environment or ADSB In equipment.  This needs to be tested, but the code change is small.

This fixes issue 428 https://github.com/apps4av/avare/issues/428