### PR TITLE
Move tracks back to "files" area from cache

### DIFF
--- a/app/src/main/java/com/ds/avare/flightLog/KMLRecorder.java
+++ b/app/src/main/java/com/ds/avare/flightLog/KMLRecorder.java
@@ -143,7 +143,7 @@ public class KMLRecorder {
     	mPositionHistory = new LinkedList<>();
     	mShape = new CrumbsShape();
     	mLastFix = new GpsParams(null);
-    	mFolder = new Preferences(ctx).getCacheFolder();
+		mFolder = new Preferences(ctx).getUserDataFolder() + File.separator + "tracks";
     }
     
     /** 

--- a/app/src/main/res/xml/filepaths.xml
+++ b/app/src/main/res/xml/filepaths.xml
@@ -1,3 +1,3 @@
 <paths>
-    <cache-path path="/" name="flighttracks" />
+    <files-path path="/" name="filespath" />
 </paths>


### PR DESCRIPTION
Moved the tracks back to the user data folder. This allows them to be exported and deleted via the IO tab. Still emails as an attachment.