### PR TITLE
Load approach

### DIFF
--- a/app/src/main/java/com/ds/avare/content/DataSource.java
+++ b/app/src/main/java/com/ds/avare/content/DataSource.java
@@ -127,9 +127,12 @@ public class DataSource {
     }
 
     public StringPreference searchOne(String name) {
-        return LocationContentProviderHelper.searchOne(mContext, name);
+        return LocationContentProviderHelper.searchOne(mContext, name, false);
     }
 
+    public StringPreference searchOneNoCache(String name) {
+        return LocationContentProviderHelper.searchOne(mContext, name, true);
+    }
     public String[] findMinimums(String airportId) {
         return LocationContentProviderHelper.findMinimums(mContext, airportId);
     }

--- a/app/src/main/java/com/ds/avare/content/LocationContentProviderHelper.java
+++ b/app/src/main/java/com/ds/avare/content/LocationContentProviderHelper.java
@@ -352,7 +352,7 @@ public class LocationContentProviderHelper {
     /**
      * Search with I am feeling lucky. Best guess
      */
-    public static StringPreference searchOne(Context ctx, String name) {
+    public static StringPreference searchOne(Context ctx, String name, boolean noCache) {
 
         if(null == name) {
             return null;
@@ -384,9 +384,11 @@ public class LocationContentProviderHelper {
         }
 
         // Search for this as a named GPS waypoint in our most recent used list
-        StringPreference sp = ContentProviderHelper.getUserRecent(ctx, name);
-        if(null != sp) {
-            return sp;
+        if(false == noCache) {
+            StringPreference sp = ContentProviderHelper.getUserRecent(ctx, name);
+            if (null != sp) {
+                return sp;
+            }
         }
 
         /*

--- a/app/src/main/java/com/ds/avare/plan/Cifp.java
+++ b/app/src/main/java/com/ds/avare/plan/Cifp.java
@@ -225,9 +225,10 @@ public class Cifp {
                 }
 
 	            /*
-	             * Search from database. Make this a simple one off search
+	             * Search from database. Make this a simple one off search. Do NOT use the "most recent"
+	             * cache - use dbase only.
 	             */
-                StringPreference s = service.getDBResource().searchOne(wp);
+                StringPreference s = service.getDBResource().searchOneNoCache(wp);
                 if(s != null) {
                     String found = s.getHashedName();
                     String id = StringPreference.parseHashedNameId(found);

--- a/app/src/main/java/com/ds/avare/shapes/MetShape.java
+++ b/app/src/main/java/com/ds/avare/shapes/MetShape.java
@@ -127,7 +127,7 @@ public class MetShape extends Shape {
                     continue;
                 }
                 if( met.shape.isOnScreen(ctx.origin) ) {
-                    met.shape.drawShape(ctx.canvas, ctx.origin, ctx.scale, ctx.movement, ctx.paint, ctx.pref.isNightMode(), true);
+                    met.shape.drawShape(ctx.canvas, ctx.origin, ctx.paint);
                 }
             }
         }

--- a/app/src/main/java/com/ds/avare/shapes/Shape.java
+++ b/app/src/main/java/com/ds/avare/shapes/Shape.java
@@ -139,24 +139,15 @@ public abstract class Shape {
      */
 	public void drawShape(Canvas c, Origin origin, Scale scale, Movement movement, Paint paint, boolean night, boolean drawTrack, Plan plan) {
 
-        /*
-         * Do a tab on top of shape
-         */
-        /*
-         * Draw pivots at end of track
-         */
-        float width = paint.getStrokeWidth();
-        int color = paint.getColor();
-        
         // TrackShape type is used for a flight plan destination
         if (this instanceof TrackShape) {
             
             /*
              * Draw background on track shapes, so draw twice. There is the
-             * the possibility of a "future" track being the same as the current or prev track, as
+             * the possibility of a "future" leg being the same as the current or prev leg, as
              * would be the case if an approach came in from a VOR, then the missed approach goes
              * back to the same VOR, or a VOR used in a procedure turn. This can be handled by
-             * cycling through the list twice and drawing them in 2 passes
+             * cycling through the list twice and drawing them in 2 passes.
              *
              * Note there is NOT a 1:1 relationship between coord's and the legs of a plan. Each
              * coord has a property that indicates its leg within the plan, use that.
@@ -165,7 +156,9 @@ public abstract class Shape {
             int currentLeg = ((null == plan) ? 0 : plan.findNextNotPassed() - 1);
 
             // Pass 1 - draw all of the legs that are AFTER the current leg
-            for(int coord = 0; coord < cMax; coord++) {
+            // We can start our search at currentLeg * 2 into the coord array due to each
+            // plan leg having at least 2 coord entries, saves a bit of looping time.
+            for(int coord = currentLeg * 2; coord < cMax; coord++) {
                 if(mCoords.get(coord).getLeg() > currentLeg) {
                     drawPlanSegment(c, origin, paint, night, drawTrack, plan, coord);
                 }
@@ -175,7 +168,7 @@ public abstract class Shape {
             for(int coord = 0; coord < cMax; coord++) {
                 if(mCoords.get(coord).getLeg() <= currentLeg) {
                     drawPlanSegment(c, origin, paint, night, drawTrack, plan, coord);
-                } else break;   // If we're past current leg, stop for() loop
+                } else break;   // If we're past current leg, stop the for() loop
             }
 
         } else {

--- a/app/src/main/java/com/ds/avare/shapes/Shape.java
+++ b/app/src/main/java/com/ds/avare/shapes/Shape.java
@@ -138,109 +138,34 @@ public abstract class Shape {
      * @param paint
      */
 	public void drawShape(Canvas c, Origin origin, Scale scale, Movement movement, Paint paint, boolean night, boolean drawTrack, Plan plan) {
+       /*
+         * Draw the shape segment by segment
+         */
+        if(getNumCoords() > 0) {
+            float pts[] = new float[(getNumCoords()) * 4];
+            int i = 0;
+            int coord = 0;
+            float x1 = (float) origin.getOffsetX(mCoords.get(coord).getLongitude());
+            float y1 = (float) origin.getOffsetY(mCoords.get(coord).getLatitude());
+            float x2;
+            float y2;
 
-        // TrackShape type is used for a flight plan destination
-        if (this instanceof TrackShape) {
-            
-            /*
-             * Draw background on track shapes, so draw twice. There is the
-             * the possibility of a "future" leg being the same as the current or prev leg, as
-             * would be the case if an approach came in from a VOR, then the missed approach goes
-             * back to the same VOR, or a VOR used in a procedure turn. This can be handled by
-             * cycling through the list twice and drawing them in 2 passes.
-             *
-             * Note there is NOT a 1:1 relationship between coord's and the legs of a plan. Each
-             * coord has a property that indicates its leg within the plan, use that.
-             */
-        	int cMax = getNumCoords() - 1;
-            int currentLeg = ((null == plan) ? 0 : plan.findNextNotPassed() - 1);
+            for (coord = 1; coord < getNumCoords(); coord++) {
+                x2 = (float) origin.getOffsetX(mCoords.get(coord).getLongitude());
+                y2 = (float) origin.getOffsetY(mCoords.get(coord).getLatitude());
 
-            // Pass 1 - draw all of the legs that are AFTER the current leg
-            // We can start our search at currentLeg * 2 into the coord array due to each
-            // plan leg having at least 2 coord entries, saves a bit of looping time.
-            for(int coord = currentLeg * 2; coord < cMax; coord++) {
-                if(mCoords.get(coord).getLeg() > currentLeg) {
-                    drawPlanSegment(c, origin, paint, night, drawTrack, plan, coord);
-                }
+                pts[i++] = x1;
+                pts[i++] = y1;
+                pts[i++] = x2;
+                pts[i++] = y2;
+
+                x1 = x2;
+                y1 = y2;
             }
-
-            // Pass 2 - draw all of the legs that are before AND the current leg
-            for(int coord = 0; coord < cMax; coord++) {
-                if(mCoords.get(coord).getLeg() <= currentLeg) {
-                    drawPlanSegment(c, origin, paint, night, drawTrack, plan, coord);
-                } else break;   // If we're past current leg, stop the for() loop
-            }
-
-        } else {
-            /*
-             * Draw the shape segment by segment
-             */
-            if(getNumCoords() > 0) {
-                float pts[] = new float[(getNumCoords()) * 4];
-                int i = 0;
-                int coord = 0;
-                float x1 = (float) origin.getOffsetX(mCoords.get(coord).getLongitude());
-                float y1 = (float) origin.getOffsetY(mCoords.get(coord).getLatitude());
-                float x2;
-                float y2;
-
-                for (coord = 1; coord < getNumCoords(); coord++) {
-                    x2 = (float) origin.getOffsetX(mCoords.get(coord).getLongitude());
-                    y2 = (float) origin.getOffsetY(mCoords.get(coord).getLatitude());
-
-                    pts[i++] = x1;
-                    pts[i++] = y1;
-                    pts[i++] = x2;
-                    pts[i++] = y2;
-
-                    x1 = x2;
-                    y1 = y2;
-                }
-                c.drawLines(pts, paint);
-            }
+            c.drawLines(pts, paint);
         }
     }
 
-    // Draw the plan segment indicated by the coord index
-    //
-    void drawPlanSegment(Canvas c, Origin origin, Paint paint, boolean night, boolean drawTrack, Plan plan, int coord) {
-        float x1 = (float)origin.getOffsetX(mCoords.get(coord).getLongitude());
-        float x2 = (float)origin.getOffsetX(mCoords.get(coord + 1).getLongitude());
-        float y1 = (float)origin.getOffsetY(mCoords.get(coord).getLatitude());
-        float y2 = (float)origin.getOffsetY(mCoords.get(coord + 1).getLatitude());
-
-        float width = paint.getStrokeWidth();
-        int color = paint.getColor();
-
-        if(drawTrack) {
-            paint.setStrokeWidth(width + 4);
-            paint.setColor(night? Color.WHITE : Color.BLACK);
-            c.drawLine(x1, y1, x2, y2, paint);
-            paint.setStrokeWidth(width);
-
-            if(null == plan) {
-                paint.setColor(color);
-            } else {
-                paint.setColor(TrackShape.getLegColor(plan, mCoords.get(coord).getLeg()));
-            }
-            c.drawLine(x1, y1, x2, y2, paint);
-        }
-
-        if(mCoords.get(coord + 1).isSeparate()) {
-            paint.setColor(night? Color.WHITE : Color.BLACK);
-            c.drawCircle(x2, y2, width + 8, paint);
-            paint.setColor(Color.GREEN);
-            c.drawCircle(x2, y2, width + 6, paint);
-            paint.setColor(color);
-        }
-        if(mCoords.get(coord).isSeparate()) {
-            paint.setColor(night? Color.WHITE : Color.BLACK);
-            c.drawCircle(x1, y1, width + 8, paint);
-            paint.setColor(Color.GREEN);
-            c.drawCircle(x1, y1, width + 6, paint);
-            paint.setColor(color);
-        }
-    }
     /*
      * Determine if shape belong to a screen based on Screen longitude and latitude
      * and shape max/min longitude latitude

--- a/app/src/main/java/com/ds/avare/shapes/Shape.java
+++ b/app/src/main/java/com/ds/avare/shapes/Shape.java
@@ -125,19 +125,13 @@ public abstract class Shape {
         }
     }
 
-    public void drawShape(Canvas c, Origin origin, Scale scale, Movement movement, Paint paint, boolean night, boolean drawTrack) {
-    	drawShape(c, origin, scale,movement,paint,night, drawTrack, null);
-    }
-    
     /**
      * This will draw the closed shape in canvas with given screen params
      * @param c
      * @param origin
-     * @param scale
-     * @param movement
      * @param paint
      */
-	public void drawShape(Canvas c, Origin origin, Scale scale, Movement movement, Paint paint, boolean night, boolean drawTrack, Plan plan) {
+	public void drawShape(Canvas c, Origin origin, Paint paint) {
        /*
          * Draw the shape segment by segment
          */

--- a/app/src/main/java/com/ds/avare/shapes/ShapeFileShape.java
+++ b/app/src/main/java/com/ds/avare/shapes/ShapeFileShape.java
@@ -132,7 +132,7 @@ public class ShapeFileShape extends Shape {
                 }
                 ctx.paint.setColor(Color.BLUE);
                 if (todraw.isOnScreen(ctx.origin)) {
-                    todraw.drawShape(ctx.canvas, ctx.origin, ctx.scale, ctx.movement, ctx.paint, ctx.pref.isNightMode(), true);
+                    todraw.drawShape(ctx.canvas, ctx.origin, ctx.paint);
                 }
             }
         }

--- a/app/src/main/java/com/ds/avare/shapes/TFRShape.java
+++ b/app/src/main/java/com/ds/avare/shapes/TFRShape.java
@@ -124,7 +124,7 @@ public class TFRShape extends Shape {
                     continue;
                 }
                 if(todraw.isOnScreen(ctx.origin) ) {
-                    todraw.drawShape(ctx.canvas, ctx.origin, ctx.scale, ctx.movement, ctx.paint, ctx.pref.isNightMode(), true);
+                    todraw.drawShape(ctx.canvas, ctx.origin, ctx.paint);
                 }
             }
         }

--- a/app/src/main/java/com/ds/avare/shapes/TrackShape.java
+++ b/app/src/main/java/com/ds/avare/shapes/TrackShape.java
@@ -92,7 +92,7 @@ public class TrackShape extends Shape {
 
         Projection p = new Projection(lastLon, lastLat, destLon, destLat);
         int segments = (int) p.getDistance() / MILES_PER_SEGMENT + 3; // Min 3 points
-        Coordinate coord[] = p.findPoints(segments);
+        Coordinate[] coord = p.findPoints(segments);
         super.mCoords.clear();
         
         /*
@@ -123,6 +123,8 @@ public class TrackShape extends Shape {
         }
     }
 
+    // draw all segments that make up this plan
+    //
     private void drawSegments(Canvas c, Origin origin, Paint paint, boolean night, boolean drawTrack, Plan plan) {
         /*
          * Draw background on track shapes, so draw twice. There is the
@@ -155,6 +157,8 @@ public class TrackShape extends Shape {
         }
     }
 
+    // draw one specific segment of the plan
+    //
     private void drawOneSegment(Canvas c, Origin origin, Paint paint, boolean night, boolean drawTrack, Plan plan, int coord) {
 
         // fetch the start and end coordinates of this segment
@@ -171,11 +175,13 @@ public class TrackShape extends Shape {
         int color = paint.getColor();
 
         if(drawTrack) {
+            // Draw the background of the track line
             paint.setStrokeWidth(width + 4);
             paint.setColor(night ? Color.WHITE : Color.BLACK);
             c.drawLine(x1, y1, x2, y2, paint);
-            paint.setStrokeWidth(width);
 
+            // Now draw the track line itself in proper color
+            paint.setStrokeWidth(width);
             if(null == plan) {
                 paint.setColor(color);
             } else {

--- a/app/src/main/java/com/ds/avare/shapes/TrackShape.java
+++ b/app/src/main/java/com/ds/avare/shapes/TrackShape.java
@@ -11,12 +11,15 @@ Redistribution and use in source and binary forms, with or without modification,
 */
 package com.ds.avare.shapes;
 
+import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.Paint;
 
 import com.ds.avare.gps.GpsParams;
 import com.ds.avare.place.Destination;
 import com.ds.avare.place.Plan;
 import com.ds.avare.position.Coordinate;
+import com.ds.avare.position.Origin;
 import com.ds.avare.position.Projection;
 import com.ds.avare.utils.BitmapHolder;
 
@@ -120,41 +123,118 @@ public class TrackShape extends Shape {
         }
     }
 
-    /**
-     * @param ctx
-     * @param plan
-     * @param destination
-     * @param params
-     * @param line
-     * @param heading
-     * @param shouldDraw
-     */
-    public static void draw(DrawingContext ctx, Plan plan, Destination destination, GpsParams params, BitmapHolder line, BitmapHolder heading, boolean shouldDraw) {
-        if((!shouldDraw) || (destination == null)) {
-            return;
+    private void drawSegments(Canvas c, Origin origin, Paint paint, boolean night, boolean drawTrack, Plan plan) {
+        /*
+         * Draw background on track shapes, so draw twice. There is the
+         * the possibility of a "future" leg being the same as the current or prev leg, as
+         * would be the case if an approach came in from a VOR, then the missed approach goes
+         * back to the same VOR, or a VOR used in a procedure turn. This can be handled by
+         * cycling through the list twice and drawing them in 2 passes.
+         *
+         * Note there is NOT a 1:1 relationship between coord's and the legs of a plan. Each
+         * coord has a property that indicates its leg within the plan, use that.
+         */
+        int cMax = getNumCoords() - 1;
+        int currentLeg = ((null == plan) ? 0 : plan.findNextNotPassed() - 1);
+        if (currentLeg < 0) currentLeg = 0; // Account for the leg of "here" to first waypoint
+
+        // Pass 1 - draw all of the legs that are AFTER the current leg
+        // We can start our search at currentLeg * 2 into the coord array due to each
+        // plan leg having at least 2 coord entries, saves a bit of looping time.
+        for(int coord = currentLeg * 2; coord < cMax; coord++) {
+            if(mCoords.get(coord).getLeg() > currentLeg) {
+                drawOneSegment(c, origin, paint, night, drawTrack, plan, coord);
+            }
         }
 
+        // Pass 2 - draw all of the legs that are before AND the current leg
+        for(int coord = 0; coord < cMax; coord++) {
+            if(mCoords.get(coord).getLeg() <= currentLeg) {
+                drawOneSegment(c, origin, paint, night, drawTrack, plan, coord);
+            } else break;   // If we're past current leg, stop the for() loop
+        }
+    }
+
+    private void drawOneSegment(Canvas c, Origin origin, Paint paint, boolean night, boolean drawTrack, Plan plan, int coord) {
+
+        // fetch the start and end coordinates of this segment
+        Coordinate thisCoord = mCoords.get(coord);
+        Coordinate nextCoord = mCoords.get(coord + 1);
+
+        // screen pixel locations of same
+        float x1 = (float)origin.getOffsetX(thisCoord.getLongitude());
+        float x2 = (float)origin.getOffsetX(nextCoord.getLongitude());
+        float y1 = (float)origin.getOffsetY(thisCoord.getLatitude());
+        float y2 = (float)origin.getOffsetY(nextCoord.getLatitude());
+
+        float width = paint.getStrokeWidth();
+        int color = paint.getColor();
+
+        if(drawTrack) {
+            paint.setStrokeWidth(width + 4);
+            paint.setColor(night ? Color.WHITE : Color.BLACK);
+            c.drawLine(x1, y1, x2, y2, paint);
+            paint.setStrokeWidth(width);
+
+            if(null == plan) {
+                paint.setColor(color);
+            } else {
+                paint.setColor(TrackShape.getLegColor(plan, thisCoord.getLeg()));
+            }
+            c.drawLine(x1, y1, x2, y2, paint);
+        }
+
+        if(nextCoord.isSeparate()) {
+            paint.setColor(night? Color.WHITE : Color.BLACK);
+            c.drawCircle(x2, y2, width + 8, paint);
+            paint.setColor(Color.GREEN);
+            c.drawCircle(x2, y2, width + 6, paint);
+            paint.setColor(color);
+        }
+
+        if(thisCoord.isSeparate()) {
+            paint.setColor(night? Color.WHITE : Color.BLACK);
+            c.drawCircle(x1, y1, width + 8, paint);
+            paint.setColor(Color.GREEN);
+            c.drawCircle(x1, y1, width + 6, paint);
+            paint.setColor(color);
+        }
+    }
+
+    // Static method called from the main LocationView object to display either a direct track
+    // line to the destination, or if a plan is active, draw that complete plan. Finally,
+    // draw the intended heading and current track pointers
+    public static void draw(DrawingContext ctx, Plan plan, Destination destination, GpsParams params, BitmapHolder line, BitmapHolder heading) {
+
+        // Set our paint line color, width, transparency
         ctx.paint.setColor(Color.MAGENTA);
         ctx.paint.setStrokeWidth(5 * ctx.dip2pix);
         ctx.paint.setAlpha(162);
+
+        // Determine which shape to draw. If we have an active plan, draw that. If not, if we have
+        // a "direct to" destination then draw that. Else, nothing to draw.
+        TrackShape trackShape = null;
         if(destination.isFound() && !plan.isActive()  && (!ctx.pref.isSimulationMode())) {
-            destination.getTrackShape().drawShape(ctx.canvas, ctx.origin, ctx.scale, ctx.movement, ctx.paint, ctx.pref.isNightMode(), ctx.pref.isTrackEnabled());
+            trackShape = destination.getTrackShape();
         } else if (plan.isActive()) {
-            plan.getTrackShape().drawShape(ctx.canvas, ctx.origin, ctx.scale, ctx.movement, ctx.paint, ctx.pref.isNightMode(), ctx.pref.isTrackEnabled(), ctx.service.getPlan());
+            trackShape = plan.getTrackShape();
         }
 
+        if (null != trackShape) {
+            trackShape.drawSegments(ctx.canvas, ctx.origin, ctx.paint, ctx.pref.isNightMode(), ctx.pref.isTrackEnabled(), plan.isActive() ? plan : null);
+        }
+
+        // if not in simulation mode, draw the track/heading lines
         if(!ctx.pref.isSimulationMode()) {
-            /*
-             * Draw actual track
-             */
+
+            // Draw actual track
             if(null != line && params != null) {
                 BitmapHolder.rotateBitmapIntoPlace(line, (float) destination.getBearing(),
                         params.getLongitude(), params.getLatitude(), false, ctx.origin);
                 ctx.canvas.drawBitmap(line.getBitmap(), line.getTransform(), ctx.paint);
             }
-            /*
-             * Draw actual heading
-             */
+
+            // Draw actual heading
             if(null != heading && params != null) {
                 BitmapHolder.rotateBitmapIntoPlace(heading, (float) params.getBearing(),
                         params.getLongitude(), params.getLatitude(), false, ctx.origin);

--- a/app/src/main/java/com/ds/avare/views/LocationView.java
+++ b/app/src/main/java/com/ds/avare/views/LocationView.java
@@ -798,10 +798,7 @@ public class LocationView extends PanZoomView implements OnTouchListener {
     }
 
     /**
-     * Draw the tracks to show our previous positions. If tracking is enabled, there is
-     * a linked list of gps coordinates attached to this view with the most recent one at the end
-     * of that list. Start at the end value to begin the drawing and as soon as we find one that is 
-     * not in the range of this display, we can assume that we're done.
+     * Draw the tracks to show our previous positions.
      * @param canvas
      * @param ctx
      */
@@ -818,7 +815,7 @@ public class LocationView extends PanZoomView implements OnTouchListener {
             mPaint.setStrokeWidth(6 * mDipToPix);
             mPaint.setStyle(Paint.Style.FILL);
 
-            mService.getKMLRecorder().getShape().drawShape(canvas, mOrigin, mScale, mMovement, mPaint, mPref.isNightMode(), true);
+            mService.getKMLRecorder().getShape().drawShape(canvas, mOrigin, mPaint);
         }
     }
 

--- a/app/src/main/java/com/ds/avare/views/LocationView.java
+++ b/app/src/main/java/com/ds/avare/views/LocationView.java
@@ -681,8 +681,10 @@ public class LocationView extends PanZoomView implements OnTouchListener {
      * @param ctx
      */
     private void drawTrack(Canvas canvas, DrawingContext ctx) {
-        TrackShape.draw(ctx, mService.getPlan(), mService.getDestination(),
-                mGpsParams, mLineBitmap, mLineHeadingBitmap, mPointProjection == null);
+        if((null == mPointProjection) && (null != mService.getDestination())) {
+            TrackShape.draw(ctx, mService.getPlan(), mService.getDestination(),
+                    mGpsParams, mLineBitmap, mLineHeadingBitmap);
+        }
     }
 
     /**


### PR DESCRIPTION
2 bugs fixed in this branch. The first has to do with loading an approach - the problem is if there is a navaid with the same ID as an airport and that airport is in the "most recent" list. ACT is an example. The fix is to NOT look at the "most recent" list when loading and resolving that approach plan.

Second bug is when drawing the flight plan legs. It's possible that a 'future' leg of the plan may overwrite the 'next' leg and you'd never see it. Consider a VOR approach with a procedure turn - the "outbound" leg of that turn would never be shown in magenta since the reciprocal inbound leg would overwrite it in cyan. The fix is to draw the un-flown legs first, then draw the past and current legs.