### PR TITLE
Clear out the "lastconnected" value when the connection is DISconnected.

### DIFF
--- a/app/src/main/java/com/ds/avare/BlueToothInFragment.java
+++ b/app/src/main/java/com/ds/avare/BlueToothInFragment.java
@@ -93,9 +93,11 @@ public class BlueToothInFragment extends Fragment {
                 /*
                  * If connected, disconnect
                  */
+                Preferences pref = new Preferences(getActivity());
                 if (mBt.isConnected()) {
                     mBt.stop();
                     mBt.disconnect();
+                    pref.setLastConnectedBtIn(null); //clear
                     setStates();
                     return;
                 }
@@ -107,13 +109,9 @@ public class BlueToothInFragment extends Fragment {
                     mConnectButton.setText(getString(R.string.Connect));
                     mBt.setHelper(((IOActivity)getActivity()).getService());
                     mBt.connect(val, mSecureCb.isChecked());
-                    Preferences pref = new Preferences(getActivity());
                     if (mBt.isConnected()) {
                         mBt.start(pref);
                         pref.setLastConnectedBtIn(val); // save where we connected
-                    }
-                    else {
-                        pref.setLastConnectedBtIn(null); //clear
                     }
                     setStates();
                 }

--- a/app/src/main/java/com/ds/avare/BlueToothOutFragment.java
+++ b/app/src/main/java/com/ds/avare/BlueToothOutFragment.java
@@ -81,9 +81,11 @@ public class BlueToothOutFragment extends Fragment {
                 /*
                  * If connected, disconnect
                  */
+                Preferences pref = new Preferences(getActivity());
                 if (mBt.isConnected()) {
                     mBt.stop();
                     mBt.disconnect();
+                    pref.setLastConnectedBtOut(null); // clear
                     setStates();
                     return;
                 }
@@ -95,13 +97,9 @@ public class BlueToothOutFragment extends Fragment {
                     mConnectButton.setText(getString(R.string.Connect));
                     mBt.setHelper(((IOActivity)getActivity()).getService());
                     mBt.connect(val, mSecureCb.isChecked());
-                    Preferences pref = new Preferences(getActivity());
                     if (mBt.isConnected()) {
                         mBt.start(pref);
                         pref.setLastConnectedBtOut(val); // save where we connected
-                    }
-                    else {
-                        pref.setLastConnectedBtOut(null); // clear
                     }
                     setStates();
                 }


### PR DESCRIPTION
This corrects a bug on startup when auto-reconnecting the bluetooth.