### PR TITLE
Ground traffic filter config (defaulted to hide), and audible min speed filter

### DIFF
--- a/app/src/main/java/com/ds/avare/StorageService.java
+++ b/app/src/main/java/com/ds/avare/StorageService.java
@@ -1241,6 +1241,7 @@ public class StorageService  {
                 getTrafficCache().putTraffic(
                         object.getString("callsign"),
                         object.getInt("address"),
+                        object.optBoolean("isairborne", true),
                         (float)object.getDouble("latitude"),
                         (float)object.getDouble("longitude"),
                         object.getInt("altitude"),
@@ -1324,6 +1325,8 @@ public class StorageService  {
                 getTrafficCache().setOwnAltitude((int) alt);
                 // set own location for proximity traffic alerts
                 getTrafficCache().setOwnLocation(l);
+                // set own airborne status
+                getTrafficCache().setOwnIsAirborne(object.optBoolean("isairborne", true));
 
                 // For own height prefer geo altitude, do not use deviceAltitude here because
                 // we could get into rising altitude condition through feedback

--- a/app/src/main/java/com/ds/avare/adsb/Traffic.java
+++ b/app/src/main/java/com/ds/avare/adsb/Traffic.java
@@ -27,6 +27,7 @@ public class Traffic {
     public int mHorizVelocity;
     public float mHeading;
     public String mCallSign;
+    public boolean mIsAirborne;
     private long mLastUpdate;
     private static Matrix mMatrix = new Matrix();
 
@@ -55,11 +56,12 @@ public class Traffic {
      * @param altitude
      * @param heading
      */
-    public Traffic(String callsign, int address, float lat, float lon, int altitude, 
+    public Traffic(String callsign, int address, boolean isAirborne, float lat, float lon, int altitude,
             float heading, int speed, long time)
     {
         mIcaoAddress = address;
         mCallSign = callsign;
+        mIsAirborne = isAirborne;
         mLon = lon;
         mLat = lat;
         mAltitude = altitude;
@@ -142,6 +144,10 @@ public class Traffic {
         for(Traffic t : traffic) {
 
             if(null == t) {
+                continue;
+            }
+            // Don't draw ground traffic, unless configuration allows it
+            if (!(t.mIsAirborne || ctx.pref.showAdsbGroundTraffic())) {
                 continue;
             }
 

--- a/app/src/main/java/com/ds/avare/adsb/TrafficCache.java
+++ b/app/src/main/java/com/ds/avare/adsb/TrafficCache.java
@@ -87,6 +87,7 @@ public class TrafficCache {
             audibleTrafficAlerts.setCriticalClosingAlertRatio(mPref.getAudibleClosingInCriticalAlertRatio());
             audibleTrafficAlerts.setAlertMaxFrequencySec(mPref.getAudibleTrafficAlertsMaxFrequency());
             audibleTrafficAlerts.setGroundAlertsEnabled(mPref.isAudibleGroundAlertsEnabled());
+            audibleTrafficAlerts.setMinSpeed(mPref.getAudibleTrafficAlertsMinSpeed());
             audibleTrafficAlerts.handleAudibleAlerts(trafficCache.getOwnLocation(), trafficCache.getTraffic(),
                     mPref.getAudibleTrafficAlertsDistanceMinimum(),trafficCache.getOwnAltitude(), trafficCache.getOwnIsAirborne());
         } else {

--- a/app/src/main/java/com/ds/avare/adsb/TrafficCache.java
+++ b/app/src/main/java/com/ds/avare/adsb/TrafficCache.java
@@ -76,17 +76,19 @@ public class TrafficCache {
 
     private void handleAudibleAlerts() {
         if (mPref.isAudibleTrafficAlerts()) {
-            AudibleTrafficAlerts audibleTrafficAlerts = AudibleTrafficAlerts.getAndStartAudibleTrafficAlerts(StorageService.getInstance().getApplicationContext());
+            final StorageService storageService = StorageService.getInstance();
+            final TrafficCache trafficCache = storageService.getTrafficCache();
+            AudibleTrafficAlerts audibleTrafficAlerts = AudibleTrafficAlerts.getAndStartAudibleTrafficAlerts(storageService.getApplicationContext());
             audibleTrafficAlerts.setUseTrafficAliases(mPref.isAudibleAlertTrafficId());
             audibleTrafficAlerts.setTopGunDorkMode(mPref.isAudibleTrafficAlertsTopGunMode());
             audibleTrafficAlerts.setClosingTimeEnabled(mPref.isAudibleClosingInAlerts());
-            audibleTrafficAlerts.setClosingTimeThreasholdSeconds(mPref.getAudibleClosingInAlertSeconds());
-            audibleTrafficAlerts.setClosestApproachThreasholdNmi(mPref.getAudibleClosingInAlertDistanceNmi());
+            audibleTrafficAlerts.setClosingTimeThresholdSeconds(mPref.getAudibleClosingInAlertSeconds());
+            audibleTrafficAlerts.setClosestApproachThresholdNmi(mPref.getAudibleClosingInAlertDistanceNmi());
             audibleTrafficAlerts.setCriticalClosingAlertRatio(mPref.getAudibleClosingInCriticalAlertRatio());
             audibleTrafficAlerts.setAlertMaxFrequencySec(mPref.getAudibleTrafficAlertsMaxFrequency());
-            audibleTrafficAlerts.handleAudibleAlerts(StorageService.getInstance().getTrafficCache().getOwnLocation(),
-                    StorageService.getInstance().getTrafficCache().getTraffic(), mPref.getAudibleTrafficAlertsDistanceMinimum() ,
-                    StorageService.getInstance().getTrafficCache().getOwnAltitude());
+            audibleTrafficAlerts.setGroundAlertsEnabled(mPref.isAudibleGroundAlertsEnabled());
+            audibleTrafficAlerts.handleAudibleAlerts(trafficCache.getOwnLocation(), trafficCache.getTraffic(),
+                    mPref.getAudibleTrafficAlertsDistanceMinimum(),trafficCache.getOwnAltitude(), trafficCache.getOwnIsAirborne());
         } else {
             AudibleTrafficAlerts.stopAudibleTrafficAlerts();
         }

--- a/app/src/main/java/com/ds/avare/adsb/TrafficCache.java
+++ b/app/src/main/java/com/ds/avare/adsb/TrafficCache.java
@@ -30,6 +30,7 @@ public class TrafficCache {
     private static final int MAX_ENTRIES = 20;
     private Traffic[] mTraffic;
     private int mOwnAltitude;
+    private boolean mOwnIsAirborne;
     private Location mOwnLocation;
     Preferences mPref;
 
@@ -95,7 +96,7 @@ public class TrafficCache {
      * 
      * @param
      */
-    public void putTraffic(String callsign, int address, float lat, float lon, int altitude, 
+    public void putTraffic(String callsign, int address, boolean isAirborne, float lat, float lon, int altitude,
             float heading, int speed, long time) {
 
         int filterAltitude = StorageService.getInstance().getPreferences().showAdsbTrafficWithin();
@@ -125,7 +126,7 @@ public class TrafficCache {
                 if(callsign.equals("")) {
                     callsign = mTraffic[i].mCallSign;
                 }
-                mTraffic[i] = new Traffic(callsign, address, lat, lon, altitude, heading, speed, time);
+                mTraffic[i] = new Traffic(callsign, address, isAirborne, lat, lon, altitude, heading, speed, time);
 
                 handleAudibleAlerts();
                 return;
@@ -138,7 +139,7 @@ public class TrafficCache {
             return;
         }
         // put it in the end
-        mTraffic[MAX_ENTRIES] = new Traffic(callsign, address, lat, lon, altitude, heading, speed, time);
+        mTraffic[MAX_ENTRIES] = new Traffic(callsign, address, isAirborne, lat, lon, altitude, heading, speed, time);
 
         // sort
         Arrays.sort(mTraffic, new TrafficComparator());
@@ -150,10 +151,14 @@ public class TrafficCache {
     public void setOwnAltitude(int altitude) {
         mOwnAltitude = altitude;
     }
+    public void setOwnIsAirborne(boolean isAirborne) {
+        mOwnIsAirborne = isAirborne;
+    }
 
     public int getOwnAltitude() {
         return mOwnAltitude;
     }
+    public boolean getOwnIsAirborne() { return mOwnIsAirborne; }
 
     public void setOwnLocation(Location loc) {
         this.mOwnLocation = loc;

--- a/app/src/main/java/com/ds/avare/adsb/gdl90/OwnshipMessage.java
+++ b/app/src/main/java/com/ds/avare/adsb/gdl90/OwnshipMessage.java
@@ -24,7 +24,7 @@ public class OwnshipMessage extends Message {
     public int mVerticalVelocity;
     public int mAltitude;
     public float mDirection;
-    boolean mIsAirborne;
+    public boolean mIsAirborne;
     boolean mIsExtrapolated;
     int mTrackType;
     int mNIC;

--- a/app/src/main/java/com/ds/avare/adsb/gdl90/TrafficReportMessage.java
+++ b/app/src/main/java/com/ds/avare/adsb/gdl90/TrafficReportMessage.java
@@ -26,6 +26,9 @@ public class TrafficReportMessage extends Message {
     public float mLon;
     public int mAltitude;
     public int mMiscInd;
+    public boolean mIsAirborne;
+    boolean mIsExtrapolated;
+    int mTrackType;
     public int mNic;
     public int mNacp;
     public int mHorizVelocity;
@@ -132,6 +135,9 @@ public class TrafficReportMessage extends Message {
          *   1       x        x        x    = airborne
          */
         mMiscInd = ((int) msg[11] & 0x0F);
+        mIsAirborne = (msg[11] & 0x08) != 0;
+        mIsExtrapolated = (msg[11] & 0x04) != 0;
+        mTrackType = msg[11] & 0x03;
 
         /*
          * Next nibble is the navigation integrity category (nic). (See GDL-90 spec pg. 21.)

--- a/app/src/main/java/com/ds/avare/connections/BufferProcessor.java
+++ b/app/src/main/java/com/ds/avare/connections/BufferProcessor.java
@@ -168,6 +168,7 @@ public class BufferProcessor {
                     object.put("type", "traffic");
                     object.put("longitude", (double)tm.mLon);
                     object.put("latitude", (double)tm.mLat);
+                    object.put("isairborne", tm.mIsAirborne);
                     object.put("speed", (double)(tm.mHorizVelocity));
                     object.put("bearing", (double)tm.mHeading);
                     object.put("altitude", (double)((double)tm.mAltitude));
@@ -515,6 +516,7 @@ public class BufferProcessor {
                     object.put("longitude", (double)om.mLon);
                     object.put("latitude", (double)om.mLat);
                     object.put("speed", (double)(om.mHorizontalVelocity));
+                    object.put("isairborne", om.mIsAirborne);
                     object.put("bearing", (double)om.mDirection);
                     object.put("time", (long)om.getTime());
                     object.put("altitude", (double) om.mAltitude);

--- a/app/src/main/java/com/ds/avare/storage/Preferences.java
+++ b/app/src/main/java/com/ds/avare/storage/Preferences.java
@@ -580,6 +580,13 @@ public class Preferences implements SharedPreferences.OnSharedPreferenceChangeLi
     /**
      * @return
      */
+    public boolean showAdsbGroundTraffic() {
+        return mPref.getBoolean(mContext.getString(R.string.ADSBTrafficIncludeGroundTraffic), false);
+    }
+
+    /**
+     * @return
+     */
     public int getTimerRingSize() {
         try {
             return (Integer.parseInt(mPref.getString(mContext.getString(R.string.prefTimerRingSize), "5")));

--- a/app/src/main/java/com/ds/avare/storage/Preferences.java
+++ b/app/src/main/java/com/ds/avare/storage/Preferences.java
@@ -930,6 +930,10 @@ public class Preferences implements SharedPreferences.OnSharedPreferenceChangeLi
         return mPref.getBoolean(mContext.getString(R.string.AudibleAlertTopGunMode), false);
     }
 
+    public boolean isAudibleGroundAlertsEnabled() {
+        return mPref.getBoolean(mContext.getString(R.string.AudibleTrafficAlertsGroundAlert), false);
+    }
+
     public boolean isAudibleAlertTrafficId() {
         return mPref.getBoolean(mContext.getString(R.string.AudibleAlertTrafficId), false);
     }

--- a/app/src/main/java/com/ds/avare/storage/Preferences.java
+++ b/app/src/main/java/com/ds/avare/storage/Preferences.java
@@ -349,6 +349,10 @@ public class Preferences implements SharedPreferences.OnSharedPreferenceChangeLi
         return Float.parseFloat(mPref.getString(mContext.getString(R.string.AudibleTrafficAlertsMaxFrequency), "15.0"));
     }
 
+    public float getAudibleTrafficAlertsMinSpeed() {
+        return Float.parseFloat(mPref.getString(mContext.getString(R.string.AudibleTrafficAlertsMinimumSpeed), "0.0"));
+    }
+
     public int getAudibleClosingInAlertSeconds() {
         return Integer.parseInt(mPref.getString(mContext.getString(R.string.AudibleTrafficAlertsClosingDistanceSeconds), "15"));
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -184,6 +184,9 @@ Redistribution and use in source and binary forms, with or without modification,
     <string name="AudibleTrafficAlertsGroundAlert">&quot;Audible Traffic Alerts Ground Alerts&quot;</string>
     <string name="AudibleTrafficAlertsGroundAlertSummary">&quot;Enable audible alerts even when the ownship or the traffic are on the ground (unchecked implies no alerts when either or both are on the ground, per the ADSB air/ground flag)&quot;</string>
     <string name="AudibleTrafficAlertsGroundAlertLabel">&quot;Audible Ground Alerts&quot;</string>
+    <string name="AudibleTrafficAlertsMinimumSpeed">&quot;Audible Traffic Alerts Minimum Speed&quot;</string>
+    <string name="AudibleTrafficAlertsMinimumSpeedSummary">&quot;Minimum (horizontal) speed over which audible alerts play, to prevent audible pollution during high workload lower-speed activities (e.g., takeoff and landing).&quot;</string>
+    <string name="AudibleTrafficAlertsMinimumSpeedLabel">&quot;Audible Alerts Min Speed (Vh)&quot;</string>
     <string name="TrackUpLabel">&quot;Track Up&quot;</string>
     <string name="TrackUpSummary">&quot;Select to show maps track up, unselect to show maps North up&quot;</string>
     <string name="TrackUpPlates">&quot;Track Up - Plates&quot;</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,6 +181,9 @@ Redistribution and use in source and binary forms, with or without modification,
     <string name="AudibleTrafficAlertsMaxFrequency">&quot;Audible Traffic Alerts Max Frequency (sec)&quot;</string>
     <string name="AudibleTrafficAlertsMaxFrequencySummary">&quot;Max frequency in seconds between which an alert for the same aircraft (by ICAO callsign) is alerted again.&quot;</string>
     <string name="AudibleTrafficAlertsMaxFrequencyLabel">&quot;Audible Traffic Alerts Max Frequency (sec)&quot;</string>
+    <string name="AudibleTrafficAlertsGroundAlert">&quot;Audible Traffic Alerts Ground Alerts&quot;</string>
+    <string name="AudibleTrafficAlertsGroundAlertSummary">&quot;Enable audible alerts even when the ownship or the traffic are on the ground (unchecked implies no alerts when either or both are on the ground, per the ADSB air/ground flag)&quot;</string>
+    <string name="AudibleTrafficAlertsGroundAlertLabel">&quot;Audible Ground Alerts&quot;</string>
     <string name="TrackUpLabel">&quot;Track Up&quot;</string>
     <string name="TrackUpSummary">&quot;Select to show maps track up, unselect to show maps North up&quot;</string>
     <string name="TrackUpPlates">&quot;Track Up - Plates&quot;</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -248,6 +248,9 @@ Redistribution and use in source and binary forms, with or without modification,
     <string name="ADSBTrafficFilter">ADSBTrafficFilter</string>
     <string name="ADSBTrafficFilterLabel">&quot;Filter ADSB Traffic&quot;</string>
     <string name="ADSBTrafficFilterSummary">&quot;Show ADSB traffic within given feet of the aircraft&quot;</string>
+    <string name="ADSBTrafficIncludeGroundTraffic">ADSBTrafficIncludeGroundTraffic</string>
+    <string name="ADSBTrafficIncludeGroundTrafficLabel">&quot;Show ADSB Ground Traffic&quot;</string>
+    <string name="ADSBTrafficIncludeGroundTrafficSummary">&quot;Display ADSB traffic that is on the ground (airborne bit not set)&quot;</string>
     <string name="prefShowAdsbCallSign">ShowAdsbCallSign</string>
     <string name="ShowAdsbCallSignLabel">&quot;Show ADSB Callsigns&quot;</string>
     <string name="ShowAdsbCallSignSummary">&quot;Select to show ADSB provided callsigns&quot;</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -360,6 +360,12 @@ authors: zkhan, jlmcgraw
             android:key="@string/AudibleTrafficAlertsDistanceMinimum"
             android:summary="@string/AudibleTrafficAlertsDistanceMinimumSummary"
             android:title="@string/AudibleTrafficAlertsDistanceMinimumLabel" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:dependency="@string/AudibleTrafficAlerts"
+            android:key="@string/AudibleTrafficAlertsGroundAlert"
+            android:summary="@string/AudibleTrafficAlertsGroundAlertSummary"
+            android:title="@string/AudibleTrafficAlertsGroundAlertLabel" />
         <com.ds.avare.utils.EditTextPreferenceWithSummary
             android:defaultValue="15"
             android:dependency="@string/AudibleTrafficAlerts"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -251,6 +251,11 @@ authors: zkhan, jlmcgraw
             android:title="@string/ADSBTrafficFilterLabel" />
         <CheckBoxPreference
             android:defaultValue="false"
+            android:key="@string/ADSBTrafficIncludeGroundTraffic"
+            android:summary="@string/ADSBTrafficIncludeGroundTrafficSummary"
+            android:title="@string/ADSBTrafficIncludeGroundTrafficLabel" />
+        <CheckBoxPreference
+            android:defaultValue="false"
             android:key="@string/drawTrafficCircles"
             android:summary="@string/drawTrafficCirclesSummary"
             android:title="@string/drawTrafficCirclesLabel" />

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -372,6 +372,12 @@ authors: zkhan, jlmcgraw
             android:key="@string/AudibleTrafficAlertsMaxFrequency"
             android:summary="@string/AudibleTrafficAlertsMaxFrequencySummary"
             android:title="@string/AudibleTrafficAlertsMaxFrequencyLabel" />
+        <com.ds.avare.utils.EditTextPreferenceWithSummary
+            android:defaultValue="0"
+            android:dependency="@string/AudibleTrafficAlerts"
+            android:key="@string/AudibleTrafficAlertsMinimumSpeed"
+            android:summary="@string/AudibleTrafficAlertsMinimumSpeedSummary"
+            android:title="@string/AudibleTrafficAlertsMinimumSpeedLabel" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:dependency="@string/AudibleTrafficAlerts"


### PR DESCRIPTION
Per Avare Github issue #371, I added the airborne ADSB flag up to the traffic object, and also saved the same flag for ownship into the traffic cache.  I then used these newly propogated flags to add configuration options for both visual and audible traffic display/alerts (both defaulted to hide the ground traffic).  In addition, per the suggestion in #371 I also added for the audible alerts the option of a mininum speed under which audible alerts are not played (defaulted to "0", which essentially means the feature/config is disabled by default), to allow for the option of effectively disabling the audible alerts completely during low-speed, high workload times like takeoff and landing--when the craft would be airborne, but still perhaps not desiring the pollution of the audible alerts when there are competing priorities and more relevant audible avionics feedback (e.g., GPWS or radio communication with the tower).  I also did a fair amount of audible alerts codebase cleanup and decomposition since my initial audible PR--sorry if that presents a little clutter vs. being able to read only the new filter items.