### PR TITLE
add customizable drawing color

### DIFF
--- a/app/src/main/assets/help.html
+++ b/app/src/main/assets/help.html
@@ -260,18 +260,26 @@
   the Center button.</p>
 
  <p>•The "<b>Pan</b>" (Pan/Draw) button allows you to jot quick
-  notes on charts. In the Maps screen, tap the Pan button at the lower-right.
+  notes on charts. In the Map or Plate screen, tap the Pan button at the lower-right.
   When the Pan button changes to the Draw button, the charts will
-  not pan, and the Map screen becomes a touch operated pen for writing or
+  not pan, and the screen becomes a touch operated pen for writing or
   drawing on charts. Draw or write notes on the screen with your finger.
   Notes length is limited due to memory size.</p>
 
  <p style="padding-left: 30px;">To erase all notes and drawings in Draw
-  mode, long press the screen and then press the <b>Clear</b> button
-  that appears.</p>
+  mode, press the <b>Clear</b> button.</p>
 
- <p style="padding-left: 30px;">To temporarily hide your notes/drawings and return to
-  normal Map functioning (Pan mode), just tap the Draw (Pan) button again.</p>
+ <p style="padding-left: 30px;">To return to
+   normal Map/Plate functioning (Pan mode), just tap the Draw (Pan) button
+   again.</p>
+
+  <p style="padding-left: 30px;">The color used for drawing can be set in
+    <b>Preferences->Display->Drawing Color</b>.  The color may be one of
+    <i>red, blue, green, black, white, gray, cyan, magenta, yellow, lightgray,
+      darkgray, grey, lightgrey, darkgrey, aqua, fuchsia, lime, maroon, navy,
+      olive, purple, silver, teal</i>
+    or may be specified using <b>#RRGGBB</b> notation.  If the color is not
+    specified or is illegal, blue with a black outline will be used.</p>
 
  <p>•<b>Long-press</b> any point on the chart (with GPS
   acquired) to display text at the top of the screen giving

--- a/app/src/main/java/com/ds/avare/storage/Preferences.java
+++ b/app/src/main/java/com/ds/avare/storage/Preferences.java
@@ -1201,4 +1201,17 @@ public class Preferences implements SharedPreferences.OnSharedPreferenceChangeLi
         mPref.edit().putString("LastConnectedWifi", val).commit();
     }
 
+    public int[] getDrawColor() {
+	int color, isDefaultColor = 0;
+
+	try {
+	    color = Color.parseColor(mPref.getString(mContext.getString(R.string.DrawColor), ""));
+	}
+	catch(IllegalArgumentException|StringIndexOutOfBoundsException e) {
+	    color = Color.BLUE;
+	    isDefaultColor = 1;
+	}
+
+	return new int[] { color, isDefaultColor };
+    }
 }

--- a/app/src/main/java/com/ds/avare/views/LocationView.java
+++ b/app/src/main/java/com/ds/avare/views/LocationView.java
@@ -700,16 +700,20 @@ public class LocationView extends PanZoomView implements OnTouchListener {
          * Get draw points.
          */
 
-        // Blue inside, black outside
         Paint.Cap oldCaps = mPaint.getStrokeCap();
         mPaint.setStrokeCap(Paint.Cap.ROUND); // We use a wide line. Without ROUND the line looks broken.
-        mPaint.setColor(Color.BLACK);
+	int[] prefColor = mPref.getDrawColor();
+
+	mPaint.setColor(prefColor[1] == 1 ? Color.BLACK : prefColor[0]);
         mPaint.setStrokeWidth(6 * mDipToPix);
         mService.getDraw().drawShape(canvas, mPaint, mOrigin);
 
-        mPaint.setColor(Color.BLUE);
-        mPaint.setStrokeWidth(2 * mDipToPix);
-        mService.getDraw().drawShape(canvas, mPaint, mOrigin);
+	if (prefColor[1] == 1)
+	{
+	    mPaint.setColor(prefColor[0]);
+	    mPaint.setStrokeWidth(2 * mDipToPix);
+	    mService.getDraw().drawShape(canvas, mPaint, mOrigin);
+	}
         mPaint.setStrokeCap(oldCaps); // Restore the Cap we had before drawing
     }
 

--- a/app/src/main/java/com/ds/avare/views/PlatesView.java
+++ b/app/src/main/java/com/ds/avare/views/PlatesView.java
@@ -195,13 +195,19 @@ public class PlatesView extends PanZoomView implements View.OnTouchListener {
     private void drawDrawing(Canvas canvas) {
         Paint.Cap oldCaps = mPaint.getStrokeCap();
         mPaint.setStrokeCap(Paint.Cap.ROUND); // We use a wide line. Without ROUND the line looks broken.
-        mPaint.setColor(Color.BLACK);
+	int[] prefColor = mPref.getDrawColor();
+
+	mPaint.setColor(prefColor[1] == 1 ? Color.BLACK : prefColor[0]);
         mPaint.setStrokeWidth(6 * mDipToPix);
         mService.getPixelDraw().drawShape(canvas, mPaint);
 
-        mPaint.setColor(Color.BLUE);
-        mPaint.setStrokeWidth(2 * mDipToPix);
-        mService.getPixelDraw().drawShape(canvas, mPaint);
+	if (prefColor[1] == 1)
+	{
+	    mPaint.setColor(prefColor[0]);
+	    mPaint.setStrokeWidth(2 * mDipToPix);
+	    mService.getPixelDraw().drawShape(canvas, mPaint);
+	}
+
         mPaint.setStrokeCap(oldCaps); // Restore the Cap we had before drawing
 
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -642,4 +642,7 @@ Redistribution and use in source and binary forms, with or without modification,
     <string name="Notes">Notes</string>
     <string name="Wx">Wx</string>
     <string name="weatherNa">Weather not available</string>
+    <string name="DrawColor">DrawColor</string>
+    <string name="DrawColorLabel">Drawing Color</string>
+    <string name="DrawColorSummary">Color for draw mode on maps and plates</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -318,6 +318,11 @@ authors: zkhan, jlmcgraw
             android:key="@string/DefaultAFD"
             android:summary="@string/DefaultAFDSummary"
             android:title="@string/DefaultAFDLabel" />
+        <com.ds.avare.utils.EditTextPreferenceWithSummary
+            android:defaultValue=""
+            android:key="@string/DrawColor"
+            android:summary="@string/DrawColorSummary"
+            android:title="@string/DrawColorLabel" />
     </PreferenceScreen>
 
 	<PreferenceScreen 


### PR DESCRIPTION
I found the default drawing color (blue with a black outline) to get lost on a busy chart like one for the SF Bay Area.  I was surprised to find that the color was hard-coded so here is a pull request to allow the color to be customized.  By default, nothing will change.  When a color is specified in Preferences->Display->Drawing Color, that color will be used (without the black outline) on the Map and Plate screens.  I also updated the help for the Pan/Draw button.

I've been a regular user of Avare for many years but this is my first (non-financial) contribution.  This is also my first foray into Java so please point out out anything that looks silly.