### PR TITLE
custom USB devices probe list is an extension to the (library) default one

### DIFF
--- a/app/src/main/res/xml/device_filter.xml
+++ b/app/src/main/res/xml/device_filter.xml
@@ -26,32 +26,20 @@
     <usb-device vendor-id="6790" product-id="29987" /> <!-- 0x7523: CH340 -->
 
     <!-- CDC driver -->
-    <usb-device vendor-id="9025" />                   <!-- 0x2341 / ......: Arduino -->
-    <usb-device vendor-id="5824" product-id="1155" /> <!-- 0x16C0 / 0x0483: Teensyduino  -->
-    <usb-device vendor-id="1003" product-id="8260" /> <!-- 0x03EB / 0x2044: Atmel Lufa -->
-    <usb-device vendor-id="7855" product-id="4"    /> <!-- 0x1eaf / 0x0004: Leaflabs Maple -->
-    <usb-device vendor-id="3368" product-id="516"  /> <!-- 0x0d28 / 0x0204: ARM mbed -->
-    <usb-device vendor-id="1155" product-id="22336" /><!-- 0x0483 / 0x5740: ST CDC -->
-    <usb-device vendor-id="11914" product-id="5"   /> <!-- 0x2E8A / 0x0005: Raspberry Pi Pico Micropython -->
-    <usb-device vendor-id="11914" product-id="10"  /> <!-- 0x2E8A / 0x000A: Raspberry Pi Pico SDK -->
-    <usb-device vendor-id="6790" product-id="21972" /><!-- 0x1A86 / 0x55D4: Qinheng CH9102F -->
+    <usb-device vendor-id="9025" />                    <!-- 0x2341 / ......: Arduino -->
+    <usb-device vendor-id="5824" product-id="1155" />  <!-- 0x16C0 / 0x0483: Teensyduino  -->
+    <usb-device vendor-id="1003" product-id="8260" />  <!-- 0x03EB / 0x2044: Atmel Lufa -->
+    <usb-device vendor-id="7855" product-id="4"    />  <!-- 0x1eaf / 0x0004: Leaflabs Maple -->
+    <usb-device vendor-id="3368" product-id="516"  />  <!-- 0x0d28 / 0x0204: ARM mbed -->
+    <usb-device vendor-id="1155" product-id="22336" /> <!-- 0x0483 / 0x5740: ST CDC -->
+    <usb-device vendor-id="11914" product-id="5"   />  <!-- 0x2E8A / 0x0005: Raspberry Pi Pico Micropython -->
+    <usb-device vendor-id="11914" product-id="10"  />  <!-- 0x2E8A / 0x000A: Raspberry Pi Pico SDK -->
+    <usb-device vendor-id="6790" product-id="21972" /> <!-- 0x1A86 / 0x55D4: Qinheng CH9102F -->
 
-    <!-- 0x0483 / 0x5740: SoftRF Dongle -->
-    <usb-device vendor-id="1155" product-id="22336" class="2" />
-
-    <!-- 0x239A / 0x8029: SoftRF Badge -->
-    <usb-device vendor-id="9114" product-id="32809" class="2" />
-
-    <!-- 0x2341 / 0x804D: SoftRF Academy -->
-    <usb-device vendor-id="9025" product-id="32845" class="2" />
-
-    <!-- 0x1D50 / 0x6089: SoftRF ES -->
-    <usb-device vendor-id="7504" product-id="24713" class="2" />
-
-    <!-- 0x2E8A / 0x000A: SoftRF Lego -->
-    <usb-device vendor-id="11914" product-id="10" class="2" />
-
-    <!-- 0x2E8A / 0xF00A: SoftRF Lego -->
-    <usb-device vendor-id="11914" product-id="61450" class="2" />
+    <usb-device vendor-id="9114" product-id="32809" /> <!-- 0x239A / 0x8029: SoftRF Badge -->
+    <usb-device vendor-id="7504" product-id="24713" /> <!-- 0x1D50 / 0x6089: SoftRF ES -->
+    <usb-device vendor-id="11914" product-id="61450" /><!-- 0x2E8A / 0xF00A: SoftRF Lego -->
+    <usb-device vendor-id="5562" product-id="68"    /> <!-- 0x15ba / 0x0044: SoftRF Balkan -->
+    <usb-device vendor-id="12346" product-id="33075" /><!-- 0x303a / 0x8133: SoftRF Prime Mk3 -->
 
 </resources>


### PR DESCRIPTION
* CustomProber class added
* duplicate (SoftRF vs default) VID/PID entries removed
* DTR signal is required for certain CDC device firmwares to trigger on their data output activity
* confirmed to work nicely with both 'default' and 'custom' devices