### PR TITLE
Permit reuse of datagram sockets

### DIFF
--- a/app/src/main/java/com/ds/avare/connections/MsfsConnection.java
+++ b/app/src/main/java/com/ds/avare/connections/MsfsConnection.java
@@ -160,6 +160,7 @@ public class MsfsConnection extends Connection {
 
         try {
             mSocket = new DatagramSocket(mPort);
+            mSocket.setReuseAddress(true);
         }
         catch(Exception e) {
             Logger.Logit("Failed! Connecting socket " + e.getMessage());

--- a/app/src/main/java/com/ds/avare/connections/WifiConnection.java
+++ b/app/src/main/java/com/ds/avare/connections/WifiConnection.java
@@ -148,6 +148,7 @@ public class WifiConnection extends Connection {
 
         try {
             mSocket = new DatagramSocket(mPort);
+            mSocket.setReuseAddress(true);
         }
         catch(Exception e) {
             Logger.Logit("Failed! Connecting socket " + e.getMessage());

--- a/app/src/main/java/com/ds/avare/connections/XplaneConnection.java
+++ b/app/src/main/java/com/ds/avare/connections/XplaneConnection.java
@@ -147,6 +147,7 @@ public class XplaneConnection extends Connection {
 
         try {
             mSocket = new DatagramSocket(mPort);
+            mSocket.setReuseAddress(true);
         }
         catch(Exception e) {
             Logger.Logit("Failed! Connecting socket " + e.getMessage());


### PR DESCRIPTION
Resolves #501

This small change sets socket reuse to TRUE for WiFi, MSFS, and XPlane connections.
