### PR TITLE
Fix missing tiles by accounting for zoomed-out tiles and extending memory budget on big RAM devices

### DIFF
--- a/app/src/main/java/com/ds/avare/shapes/Tile.java
+++ b/app/src/main/java/com/ds/avare/shapes/Tile.java
@@ -332,10 +332,16 @@ public class Tile {
              */
 
             tile.getTransform().setScale(scaleFactor, scaleFactor);
+
+            int tileXIndex = tilen % tiles.getXTilesNum();
+            int tileYIndex = tilen / tiles.getXTilesNum();
+            int centerTileX = (int)(tiles.getXTilesNum() / 2);
+            int centerTileY = (int)(tiles.getYTilesNum() / 2);
+
             tile.getTransform().postTranslate(
                     ctx.view.getWidth()  / 2.f
                             + ( - BitmapHolder.WIDTH  / 2.f
-                            + ((tilen % tiles.getXTilesNum()) * BitmapHolder.WIDTH - BitmapHolder.WIDTH * (int)(tiles.getXTilesNum() / 2))
+                            + ((tileXIndex - centerTileX) * BitmapHolder.WIDTH)
                             + ctx.pan.getMoveX()
                             + ctx.pan.getTileMoveX() * BitmapHolder.WIDTH
                             - (float)ctx.movement.getOffsetLongitude()) * scaleFactor,
@@ -343,7 +349,7 @@ public class Tile {
                     ctx.view.getHeight() / 2.f
                             + ( - BitmapHolder.HEIGHT / 2.f
                             + ctx.pan.getMoveY()
-                            + ((tilen / tiles.getXTilesNum()) * BitmapHolder.HEIGHT - BitmapHolder.HEIGHT * (int)(tiles.getYTilesNum() / 2))
+                            + ((tileYIndex - centerTileY) * BitmapHolder.HEIGHT)
                             + ctx.pan.getTileMoveY() * BitmapHolder.HEIGHT
                             - (float)ctx.movement.getOffsetLatitude() ) * scaleFactor);
 


### PR DESCRIPTION
Partial fix to issue #365

This commit addresses two issues with tile rendering that cause the display to have black regions (missing tiles) where it shouldn't.

In Preferences.java, it increases the tile budget by a factor of 2. Specifically, it divides by 0.5, my understanding of the smallest zoom size before we flip to the next zoom level.  I used a float there as documentation because maybe someday that magic number changes?
==> But let me know if I should just ditch the goofy float math and int-multiply by 2.

That fix wasn't enough, because I'd still see missing tiles because the budget gets clipped by getTilesNumber to the MEM_*_{X,Y} memory limits. The biggest memory limit was based on a whopping 192MB device. My tablet has 4GB and would like more tiles, please. I added a MEM_512 tier with 13×11 tiles. ==> I don't know how the MEM_512_OH value should be calculated. Suggestions invited.

In the process of diagnosing these issues, I was getting terribly confused by the draw loop in Tile.java. I refactored it a little to extract some expressions that have intuitive meaning (tileXIndex, tileYIndex, centerTileX, centerTileY) and compute based on those. I think this change is just aesthetic.

I tested this manually on an Android emulator by reproducing zoom levels that cause trouble on my tablet.