### PR TITLE
Use evaluateJavascript instead of loadUrl("javascript:...") in WebApp interfaces

### DIFF
--- a/app/src/main/java/com/ds/avare/webinfc/WebAppAircraftInterface.java
+++ b/app/src/main/java/com/ds/avare/webinfc/WebAppAircraftInterface.java
@@ -566,30 +566,30 @@ public class WebAppAircraftInterface {
                  */
         		String[] steps = mList.getStepsArray();
             	for(int num = 0; num < steps.length; num++) {
-            		String url = "javascript:set_list_line(" + 
+            		String url = "set_list_line(" + 
             				num + "," +
             				(mList.isSelected(num) ? 1 : 0) + ",'" + steps[num] + "')";
-            		mWebView.loadUrl(url);
+            		mWebView.evaluateJavascript(url, null);
             	}
             	
             	if(null != mList.getName()) {
-            		mWebView.loadUrl("javascript:list_setname('" + mList.getName() + "')");
+            		mWebView.evaluateJavascript("list_setname('" + mList.getName() + "')", null);
             	}
         	}
         	else if(MSG_CLEAR_LIST == msg.what) {
-        		mWebView.loadUrl("javascript:list_clear()");
+        		mWebView.evaluateJavascript("list_clear()", null);
         	}
         	else if(MSG_ADD_LIST == msg.what) {
-            	String func = "javascript:list_add(" + (String)msg.obj + ")";
-            	mWebView.loadUrl(func);
+            	String func = "list_add(" + (String)msg.obj + ")";
+            	mWebView.evaluateJavascript(func, null);
         	}
         	else if(MSG_CLEAR_LIST_SAVE == msg.what) {
-            	String func = "javascript:save_clear()";
-            	mWebView.loadUrl(func);
+            	String func = "save_clear()";
+            	mWebView.evaluateJavascript(func, null);
         	}
         	else if(MSG_ADD_LIST_SAVE == msg.what) {
-            	String func = "javascript:save_add(" + (String)msg.obj + ")";
-            	mWebView.loadUrl(func);
+            	String func = "save_add(" + (String)msg.obj + ")";
+            	mWebView.evaluateJavascript(func, null);
         	}
         	else if(MSG_NOTBUSY == msg.what) {
         		mCallback.callback((Object) AircraftActivity.UNSHOW_BUSY, null);
@@ -606,17 +606,17 @@ public class WebAppAircraftInterface {
                     String data = mWnb.getJSON().toString();
 
                     if (null != data) {
-                        mWebView.loadUrl("javascript:wnb_set('" + data + "')");
+                        mWebView.evaluateJavascript("wnb_set('" + data + "')", null);
                     }
                 }
             }
             else if(MSG_ADD_WNB_SAVE == msg.what) {
-                String func = "javascript:wnb_save_add(" + (String)msg.obj + ")";
-                mWebView.loadUrl(func);
+                String func = "wnb_save_add(" + (String)msg.obj + ")";
+                mWebView.evaluateJavascript(func, null);
             }
             else if(MSG_CLEAR_WNB_SAVE == msg.what) {
-                String func = "javascript:wnb_save_clear()";
-                mWebView.loadUrl(func);
+                String func = "wnb_save_clear()";
+                mWebView.evaluateJavascript(func, null);
             }
 
 
@@ -625,17 +625,17 @@ public class WebAppAircraftInterface {
                     String data = mAircraft.getJSON();
 
                     if (null != data) {
-                        mWebView.loadUrl("javascript:ac_set('" + data + "')");
+                        mWebView.evaluateJavascript("ac_set('" + data + "')", null);
                     }
                 }
             }
             else if(MSG_ADD_AC_SAVE == msg.what) {
-                String func = "javascript:ac_save_add(" + (String)msg.obj + ")";
-                mWebView.loadUrl(func);
+                String func = "ac_save_add(" + (String)msg.obj + ")";
+                mWebView.evaluateJavascript(func, null);
             }
             else if(MSG_CLEAR_AC_SAVE == msg.what) {
-                String func = "javascript:ac_save_clear()";
-                mWebView.loadUrl(func);
+                String func = "ac_save_clear()";
+                mWebView.evaluateJavascript(func, null);
             }
 
         }

--- a/app/src/main/java/com/ds/avare/webinfc/WebAppMapInterface.java
+++ b/app/src/main/java/com/ds/avare/webinfc/WebAppMapInterface.java
@@ -170,7 +170,7 @@ public class WebAppMapInterface {
 
                 // type from map or from search
                 String type = data.hasMoreButtons() ? "more" : "";
-                String func = "javascript:setData('" +
+                String func = "setData('" +
                         type + "','" +
                         Helper.formatJsArgs(data.getAirport()) + "','" +
                         Helper.formatJsArgs(data.getInfo()) + "','" +
@@ -187,7 +187,7 @@ public class WebAppMapInterface {
 
 
 
-                mWebView.loadUrl(func);
+                mWebView.evaluateJavascript(func, null);
             }
             else if (MSG_ACTION == msg.what) {
                 mCallback.callback((String)msg.obj, null);

--- a/app/src/main/java/com/ds/avare/webinfc/WebAppPlanInterface.java
+++ b/app/src/main/java/com/ds/avare/webinfc/WebAppPlanInterface.java
@@ -1410,27 +1410,27 @@ public class WebAppPlanInterface implements Observer {
         @Override
         public void handleMessage(Message msg) {
         	if(MSG_CLEAR_PLAN == msg.what) {
-        		mWebView.loadUrl("javascript:plan_clear()");
+        		mWebView.evaluateJavascript("plan_clear()", null);
         	}
         	else if(MSG_ADD_PLAN == msg.what) {
-            	String func = "javascript:plan_add(" + (String)msg.obj + ")";
-            	mWebView.loadUrl(func);
+            	String func = "plan_add(" + (String)msg.obj + ")";
+            	mWebView.evaluateJavascript(func, null);
         	}
         	else if(MSG_ADD_SEARCH == msg.what) {
-            	String func = "javascript:search_add(" + (String)msg.obj + ")";
-            	mWebView.loadUrl(func);
+            	String func = "search_add(" + (String)msg.obj + ")";
+            	mWebView.evaluateJavascript(func, null);
         	}
         	else if (MSG_TIMER == msg.what) {
 				Plan plan = mService.getPlan();
         		plan.simulate();
         	}
         	else if(MSG_CLEAR_PLAN_SAVE == msg.what) {
-            	String func = "javascript:save_clear()";
-            	mWebView.loadUrl(func);
+            	String func = "save_clear()";
+            	mWebView.evaluateJavascript(func, null);
         	}
         	else if(MSG_ADD_PLAN_SAVE == msg.what) {
-            	String func = "javascript:save_add(" + (String)msg.obj + ")";
-            	mWebView.loadUrl(func);
+            	String func = "save_add(" + (String)msg.obj + ")";
+            	mWebView.evaluateJavascript(func, null);
         	}
         	else if(MSG_NOTBUSY == msg.what) {
         		mCallback.callback((Object)PlanActivity.UNSHOW_BUSY, null);
@@ -1445,31 +1445,31 @@ public class WebAppPlanInterface implements Observer {
         		mCallback.callback((Object)PlanActivity.INACTIVE, null);
         	}
            	else if(MSG_SAVE_HIDE == msg.what) {	
-            	String func = "javascript:save_hide(" + (String)msg.obj + ")";
-            	mWebView.loadUrl(func);
+            	String func = "save_hide(" + (String)msg.obj + ")";
+            	mWebView.evaluateJavascript(func, null);
         	}
            	else if(MSG_PREV_HIDE == msg.what) {	
-            	String func = "javascript:disable_prev(" + (String)msg.obj + ")";
-            	mWebView.loadUrl(func);
+            	String func = "disable_prev(" + (String)msg.obj + ")";
+            	mWebView.evaluateJavascript(func, null);
         	}
            	else if(MSG_NEXT_HIDE == msg.what) {	
-            	String func = "javascript:disable_next(" + (String)msg.obj + ")";
-            	mWebView.loadUrl(func);
+            	String func = "disable_next(" + (String)msg.obj + ")";
+            	mWebView.evaluateJavascript(func, null);
         	}
            	else if(MSG_PLAN_COUNT == msg.what) {	
-            	String func = "javascript:set_plan_count(" + (String)msg.obj + ")";
-            	mWebView.loadUrl(func);
+            	String func = "set_plan_count(" + (String)msg.obj + ")";
+            	mWebView.evaluateJavascript(func, null);
         	}
 			else if(MSG_UPDATE_WEATHER == msg.what) {
-				String func = "javascript:update_weather(" + (String)msg.obj + ")";
-				mWebView.loadUrl(func);
+				String func = "update_weather(" + (String)msg.obj + ")";
+				mWebView.evaluateJavascript(func, null);
 			}
 			else if(MSG_ERROR == msg.what) {
         		mCallback.callback((Object)PlanActivity.MESSAGE, msg.obj);
         	}
 			else if(MSG_FILL_FORM == msg.what) {
-				String func = "javascript:plan_fill(" + (String)msg.obj + ")";
-				mWebView.loadUrl(func);
+				String func = "plan_fill(" + (String)msg.obj + ")";
+				mWebView.evaluateJavascript(func, null);
 			}
 			else if(MSG_FAA_PLANS == msg.what) {
 				/*
@@ -1485,12 +1485,12 @@ public class WebAppPlanInterface implements Observer {
 					p += ((i == mFaaPlans.mSelectedIndex) ? "1" : "0") + "," + pl.departure + "-" + pl.destination + "-" + pl.aircraftId + "," + pl.currentState + ",";
 					i++;
 				}
-				String func = "javascript:set_faa_plans('" + p + "')";
-				mWebView.loadUrl(func);
+				String func = "set_faa_plans('" + p + "')";
+				mWebView.evaluateJavascript(func, null);
 			}
 			else if(MSG_SET_EMAIL == msg.what) {
-				String func = "javascript:set_email('" + mPref.getRegisteredEmail() + "')";
-				mWebView.loadUrl(func);
+				String func = "set_email('" + mPref.getRegisteredEmail() + "')";
+				mWebView.evaluateJavascript(func, null);
 			}
 
 


### PR DESCRIPTION
Closes #531.

### What changes

Across the three webinfc bridge classes, every `mWebView.loadUrl("javascript:...")` is replaced with `mWebView.evaluateJavascript(script, null)` and the `"javascript:"` prefix is stripped from the JS snippet strings.

Files touched:

- `app/src/main/java/com/ds/avare/webinfc/WebAppAircraftInterface.java`
- `app/src/main/java/com/ds/avare/webinfc/WebAppMapInterface.java`
- `app/src/main/java/com/ds/avare/webinfc/WebAppPlanInterface.java`

26 call sites in total. Sample:

```diff
 else if(MSG_CLEAR_LIST == msg.what) {
-    mWebView.loadUrl("javascript:list_clear()");
+    mWebView.evaluateJavascript("list_clear()", null);
 }
 else if(MSG_ADD_LIST == msg.what) {
-    String func = "javascript:list_add(" + (String)msg.obj + ")";
-    mWebView.loadUrl(func);
+    String func = "list_add(" + (String)msg.obj + ")";
+    mWebView.evaluateJavascript(func, null);
 }
```

`evaluateJavascript` runs the JS without touching the WebView navigation stack, which is what every one of these helpers actually wants. The visible behaviour stays the same.
